### PR TITLE
Feature/health engine

### DIFF
--- a/dockfleet/health/seed.py
+++ b/dockfleet/health/seed.py
@@ -1,13 +1,23 @@
+from sqlmodel import Session
 from dockfleet.cli.config import load_config
 from dockfleet.health.models import init_db, engine
-from sqlmodel import Session 
 from dockfleet.health.services import seed_services
 
-def main() -> None:
-    config = load_config("examples/dockfleet.yaml")
+def bootstrap_from_config(config_path: str = "examples/dockfleet.yaml") -> None:
+    # 1) Load YAML → DockFleetConfig
+    config = load_config(config_path)
+
+    # 2) Ensure DB and tables exist
     init_db()
+
+    # 3) Open session and seed services
     with Session(engine) as session:
         seed_services(config, session)
+
+def main() -> None:
+    # For now, just calling bootstrap with default example path.
+    # Later, CLI can pass a custom path or integrate with `dockfleet up`.
+    bootstrap_from_config()
 
 if __name__ == "__main__":
     main()

--- a/dockfleet/health/seed.py
+++ b/dockfleet/health/seed.py
@@ -1,0 +1,13 @@
+from dockfleet.cli.config import load_config
+from dockfleet.health.models import init_db, engine
+from sqlmodel import Session 
+from dockfleet.health.services import seed_services
+
+def main() -> None:
+    config = load_config("examples/dockfleet.yaml")
+    init_db()
+    with Session(engine) as session:
+        seed_services(config, session)
+
+if __name__ == "__main__":
+    main()

--- a/dockfleet/health/seed.py
+++ b/dockfleet/health/seed.py
@@ -1,23 +1,28 @@
 from sqlmodel import Session
-from dockfleet.cli.config import load_config
+from dockfleet.cli.config import load_config, DockFleetConfig
 from dockfleet.health.models import init_db, engine
 from dockfleet.health.services import seed_services
 
-def bootstrap_from_config(config_path: str = "examples/dockfleet.yaml") -> None:
-    # 1) Load YAML → DockFleetConfig
-    config = load_config(config_path)
-
-    # 2) Ensure DB and tables exist
+def bootstrap_from_config(config: DockFleetConfig) -> None:
+    # 1) Ensure DB and tables exist
     init_db()
 
-    # 3) Open session and seed services
+    # 2) Open session and seed services (idempotent)
     with Session(engine) as session:
         seed_services(config, session)
 
+def bootstrap_from_path(config_path: str = "examples/dockfleet.yaml") -> None:
+    # Load YAML → DockFleetConfig
+    config = load_config(config_path)
+
+    # Delegate to the in-memory bootstrap
+    bootstrap_from_config(config)
+
 def main() -> None:
-    # For now, just calling bootstrap with default example path.
+    # For now, just call bootstrap with default example path.
     # Later, CLI can pass a custom path or integrate with `dockfleet up`.
-    bootstrap_from_config()
+    bootstrap_from_path()
+
 
 if __name__ == "__main__":
     main()

--- a/docs/health_engine_design.md
+++ b/docs/health_engine_design.md
@@ -1,26 +1,66 @@
-## 1. Responsibilities
-- track service health status
-- auto-restart on failures
-- store restart history
-- sync with YAML config (ServiceConfig)
+## 1. Responsibilities (Health & State Engine)
+
+- Track per-service health status (running / unhealthy / restarting / stopped).
+- Auto-restart on failures (based on restart policy).
+- Store restart history and basic crash reasons.
+- Stay in sync with YAML config (`DockFleetConfig` / `ServiceConfig`).
+- Expose a simple API so CLI (`dockfleet seed`) and orchestrator (`up(config)`) can hook in easily.
 
 ## 2. Config → Service mapping
-- DockFleetConfig.services[name] → Service.name
-- ServiceConfig.image → Service.image
-- ServiceConfig.restart → Service.restart_policy
-- ServiceConfig.ports → Service.ports_raw
-- ServiceConfig.healthcheck → Service.healthcheck_raw
 
-## 3. Functions
-### from_config(config: DockFleetConfig) -> list[Service]
-- input: parsed YAML config
-- output: list of Service objects (not yet in DB)
-- steps:
-  - loop over config.services.items()
-  - map fields
-  - set runtime defaults (status, restart_count, etc.)
+Given `DockFleetConfig.services: Dict[str, ServiceConfig]`:
 
-### seed_services(config, session)
-- input: config + DB session
-- behavior: insert Service rows if not already present
-- idempotent: safe to call multiple times
+- `name` (dict key) → `Service.name`
+- `ServiceConfig.image` → `Service.image`
+- `ServiceConfig.restart` → `Service.restart_policy` (values: `always`, `on-failure`, `never`)
+- `ServiceConfig.ports` → `Service.ports_raw` (serialized list, e.g. JSON or comma-separated)
+- `ServiceConfig.healthcheck` → `Service.healthcheck_raw` (serialized `HealthCheckConfig`)
+- Runtime fields set by health engine:
+  - `Service.status` → `"unknown"` / `"pending"` initially, later `"running"`, `"unhealthy"`, etc.
+  - `Service.restart_count` → `0` initially.
+  - `Service.last_health_check` → `NULL` initially.
+  - `Service.last_failure_reason` → `NULL` initially.
+
+
+## 3. Public health-engine functions
+
+### 3.1 from_config(config: DockFleetConfig) -> list[Service]
+
+- Input: parsed YAML config (`DockFleetConfig`).
+- Output: list of `Service` objects (NOT yet written to DB).
+- Steps:
+  - Loop over `config.services.items()` (`name`, `ServiceConfig`).
+  - Map config fields to `Service` fields using the mapping above.
+  - Set runtime defaults (`status`, `restart_count`, `last_health_check`, `last_failure_reason`).
+  - Return the list of `Service` instances.
+
+### 3.2 seed_services(config: DockFleetConfig, session: Session) -> None
+
+- Input: `DockFleetConfig` + SQLModel `Session`.
+- Behavior:
+  - For each `Service` from `from_config(config)`:
+    - If a row with the same `Service.name` already exists in DB → leave as is.
+    - If it does not exist → insert a new row.
+- Idempotent:
+  - Safe to call multiple times with the same config without creating duplicates.
+
+### 3.3 bootstrap_from_config(config: DockFleetConfig) -> None
+
+- Input: in-memory `DockFleetConfig` object.
+- Behavior:
+  - Calls `init_db()` to ensure SQLite file and tables exist.
+  - Opens a `Session(engine)`.
+  - Calls `seed_services(config, session)` to sync `Service` rows with YAML.
+- Intended usage:
+  - Orchestrator can call this before or during `up(config)` if it wants automatic seeding.
+  - Tests and scripts can call this directly.
+
+### 3.4 bootstrap_from_path(path: str = "examples/dockfleet.yaml") -> None
+
+- Input: path to a DockFleet YAML file.
+- Behavior:
+  - Calls `load_config(path)` to get a `DockFleetConfig`.
+  - Delegates to `bootstrap_from_config(config)`.
+- Intended usage:
+  - `dockfleet seed` CLI command (Typer) should call this function.
+  - `python -m dockfleet.health.seed` currently uses this for local dev.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn==0.29.0
 jinja2==3.1.3
 pydantic
 pyyaml
+pytest

--- a/tests/test_bootstrap_integration.py
+++ b/tests/test_bootstrap_integration.py
@@ -1,0 +1,32 @@
+from sqlmodel import Session, select
+from dockfleet.cli.config import DockFleetConfig, load_config
+from dockfleet.health.models import Service, init_db, engine
+from dockfleet.health.seed import bootstrap_from_config
+
+
+def test_bootstrap_from_config_seeds_services(tmp_path):
+    """
+    Integration-style test for YAML -> DockFleetConfig -> SQLite services table.
+
+    This does NOT start Docker containers yet; orchestrator's `up(config)`
+    can be plugged into the same pattern later.
+    """
+    # Arrange: load example config (or point to a test YAML under tests/data)
+    config: DockFleetConfig = load_config("examples/dockfleet.yaml")
+
+    # Act: init DB + seed via bootstrap
+    init_db()
+    bootstrap_from_config(config)
+
+    # Assert: services table has one row per service in config
+    with Session(engine) as session:
+        services_in_db = session.exec(select(Service)).all()
+
+    # Number of services configured in YAML
+    expected_count = len(config.services)
+
+    assert len(services_in_db) == expected_count
+
+    names_in_db = {s.name for s in services_in_db}
+    expected_names = set(config.services.keys())
+    assert names_in_db == expected_names

--- a/tests/test_seed_services.py
+++ b/tests/test_seed_services.py
@@ -1,0 +1,49 @@
+import pytest
+from sqlmodel import SQLModel, create_engine, Session, select
+from dockfleet.health.models import Service
+from dockfleet.health.seed import seed_services
+from dockfleet.cli.config import DockFleetConfig, ServiceConfig, HealthCheckConfig, RestartPolicy
+
+
+def make_test_config() -> DockFleetConfig:
+    return DockFleetConfig(
+        services={
+            "api": ServiceConfig(
+                image="my-api:latest",
+                ports=["8000:8000"],
+                healthcheck=HealthCheckConfig(
+                    type="http",
+                    endpoint="http://localhost:8000/health",
+                    interval=30,
+                ),
+                restart=RestartPolicy.always,
+            ),
+            "redis": ServiceConfig(
+                image="redis:7",
+                ports=None,
+                healthcheck=None,
+                restart=RestartPolicy.always,
+            ),
+        }
+    )
+
+
+def test_seed_services_idempotent():
+    # in‑memory SQLite engine
+    engine = create_engine("sqlite://")
+
+    # create tables in memory
+    SQLModel.metadata.create_all(engine)
+
+    config = make_test_config()
+
+    with Session(engine) as session:
+        # first seed
+        seed_services(config, session)
+        count_after_first = session.exec(select(Service)).all()
+        assert len(count_after_first) == 2
+
+        # second seed (should not duplicate)
+        seed_services(config, session)
+        count_after_second = session.exec(select(Service)).all()
+        assert len(count_after_second) == 2


### PR DESCRIPTION
- Add health-engine bootstrap helpers to init SQLite and seed Service rows from DockFleetConfig.
- Wire YAML→DB flow via bootstrap_from_path and bootstrap_from_config for future dockfleet seed / up integration.
- Add integration and idempotency tests to verify seeding behavior and DB state.