### PR TITLE
feat(cli): implement DockFleet CLI validation command

### DIFF
--- a/dockfleet/cli/config.py
+++ b/dockfleet/cli/config.py
@@ -1,63 +1,75 @@
 from enum import Enum
 from pathlib import Path
-from pydantic import BaseModel, Field, config, field_validator
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List, Dict
 import yaml
+import re
 
-#healthcheck model
+# healthcheck model
 class HealthCheckConfig(BaseModel):
     type: str
     endpoint: Optional[str] = None
     interval: Optional[int] = None
 
-#Restart policy Enum
+# Restart policy Enum
 class RestartPolicy(str, Enum):
     always = "always"
     on_failure = "on-failure"
     never = "never"
 
-#service model
+# Resource limits model
+class ResourcesConfig(BaseModel):
+    memory: Optional[str] = None
+    cpu: Optional[float] = None
+
+# service model
 class ServiceConfig(BaseModel):
     image: str
-    ports: Optional[List[str]] = None
-    healthcheck: Optional["HealthCheckConfig"] = None
     restart: RestartPolicy
-
-#Root Config Model
-class DockFleetConfig(BaseModel):
-    services: Dict[str, ServiceConfig]
-
-#load function
-def load_config(path: str) -> DockFleetConfig:
-    with open(path, "r") as f:
-        data = yaml.safe_load(f)
-
-    return DockFleetConfig(**data)
-
-#Resource limits model
-class ResourcesConfig(BaseModel):
-    image:str
-    restart: str
-
     ports: Optional[List[str]] = None
     healthcheck: Optional[HealthCheckConfig] = None
     resources: Optional[ResourcesConfig] = None
     depends_on: Optional[List[str]] = None
     environment: Optional[List[str]] = None
 
-    @field_validator("restart")
+    @field_validator("ports")
     @classmethod
-    def validate_restart_policy(cls, value):
-        allowed = {"always", "on-failure", "never"}
-        if value not in allowed:
-            raise ValueError(f"restart must be one of {allowed}")
+    def validate_ports(cls, value):
+        if value is None:
+            return value
+
+        pattern = re.compile(r"^\d+:\d+$")
+
+        for port in value:
+            if not pattern.match(port):
+                raise ValueError(
+                    f"Invalid port mapping '{port}'. Expected format 'host:container'"
+                )
+
         return value
-    
-#YAML loader
+
+    @field_validator("healthcheck")
+    @classmethod
+    def validate_healthcheck(cls, value):
+        if value is None:
+            return value
+
+        if value.type is None:
+            raise ValueError("healthcheck.type is required")
+
+        if value.interval is None:
+            raise ValueError("healthcheck.interval is required")
+
+        return value
+
+# Root Config Model
+class DockFleetConfig(BaseModel):
+    services: Dict[str, ServiceConfig]
+
+# YAML loader
 def load_config(path: Path) -> DockFleetConfig:
     with open(path, "r") as f:
         data = yaml.safe_load(f)
-
     if not data:
         raise ValueError("Config file is empty")
 

--- a/dockfleet/cli/main.py
+++ b/dockfleet/cli/main.py
@@ -1,0 +1,30 @@
+import typer
+from pathlib import Path
+from pydantic import ValidationError
+from dockfleet.cli.config import load_config
+
+app = typer.Typer()
+
+validate_app = typer.Typer()
+app.add_typer(validate_app, name="validate")
+
+@validate_app.callback(invoke_without_command=True)
+def validate(path: Path = typer.Argument("dockfleet.yaml")):
+    """Validate a DockFleet configuration file."""
+    try:
+        load_config(path)
+        typer.echo("Config valid")
+
+    except ValidationError as e:
+        typer.echo("Config validation failed")
+        for err in e.errors():
+            location = " -> ".join(str(x) for x in err["loc"])
+            typer.echo(f"{location}: {err['msg']}")
+        raise typer.Exit(code=1)
+
+    except Exception as e:
+        typer.echo(f"Unexpected error: {e}")
+        raise typer.Exit(code=1)
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "dockfleet"
+version = "0.1.0"
+
+[project.scripts]
+dockfleet = "dockfleet.cli.main:app"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sqlmodel
 pydantic
 pyyaml
 pytest
+typer

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,10 @@
+from typer.testing import CliRunner
+from dockfleet.cli.main import app
+
+runner = CliRunner()
+
+
+def test_cli_validate_success():
+    result = runner.invoke(app, ["examples/dockfleet.yaml"])
+    assert result.exit_code == 0
+    assert "Config valid" in result.stdout


### PR DESCRIPTION
This PR adds the CLI validation feature for DockFleet.

### What was implemented

1. Added a Typer-based CLI entrypoint in dockfleet/cli/main.py.

2. Implemented the command:

`dockfleet validate [PATH]`

to validate a DockFleet YAML configuration file.
3. The command internally calls load_config() which:
4. loads the YAML file using PyYAML
5. validates it using the Pydantic config models
6.checks restart policy, port mappings, and healthcheck configuration.

### CLI Usage
Example:

`dockfleet validate examples/dockfleet.yaml`

Output:

`Config valid`

If the configuration is invalid, the CLI prints readable validation errors.


### Tests

- Added CLI tests in tests/test_cli.py.
- All tests pass using pytest.

Files included: 

dockfleet/cli/main.py
tests/test_cli.py
pyproject.toml
requirements.txt
dockfleet/cli/config.py