### PR TITLE
feat(health-engine): add DB status sync and basic health checks

### DIFF
--- a/dockfleet/health/checker.py
+++ b/dockfleet/health/checker.py
@@ -1,0 +1,101 @@
+import logging
+import socket
+import subprocess
+from typing import Optional
+
+import requests
+
+
+class HealthChecker:
+    def __init__(self) -> None:
+        # Simple logger for health checks
+        self._logger = logging.getLogger(__name__)
+
+    def check_http(self, endpoint: str, timeout: float = 3.0) -> bool:
+        """
+        Return True if HTTP endpoint looks healthy, else False.
+        Healthy = 2xx or 3xx status code.
+        """
+        try:
+            resp = requests.get(endpoint, timeout=timeout)
+            code = resp.status_code
+
+            if 200 <= code < 400:
+                self._logger.info("HTTP OK %s (status=%s)", endpoint, code)
+                return True
+
+            self._logger.warning(
+                "HTTP UNHEALTHY %s (status=%s)", endpoint, code
+            )
+            return False
+
+        except requests.RequestException as exc:
+            self._logger.warning(
+                "HTTP check FAILED %s (%s)", endpoint, exc
+            )
+            return False
+
+    def check_tcp(self, host: str, port: int, timeout: float = 3.0) -> bool:
+        # Return True if TCP connection to host:port succeeds, else False.
+        try:
+            sock: Optional[socket.socket] = None
+            sock = socket.create_connection((host, port), timeout=timeout)
+            self._logger.info("TCP OK %s:%s", host, port)
+            return True
+        except OSError as exc:
+            self._logger.warning(
+                "TCP check FAILED %s:%s (%s)", host, port, exc
+            )
+            return False
+        finally:
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+
+    def check_process(self, container_name: str) -> bool:
+        """
+        Return True if Docker container is running, else False.
+
+        Uses:
+            docker inspect -f "{{.State.Running}}" <container_name>
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "docker",
+                    "inspect",
+                    "-f",
+                    "{{.State.Running}}",
+                    container_name,
+                ],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            # docker CLI not installed / not on PATH
+            self._logger.warning(
+                "Process check FAILED for %s (docker CLI not found)",
+                container_name,
+            )
+            return False
+
+        if result.returncode != 0:
+            # e.g. container does not exist
+            self._logger.warning(
+                "Process check FAILED for %s (docker inspect error: %s)",
+                container_name,
+                result.stderr.strip(),
+            )
+            return False
+
+        output = result.stdout.strip().lower()
+        if output == "true":
+            self._logger.info("PROCESS OK %s (running)", container_name)
+            return True
+
+        self._logger.warning(
+            "PROCESS UNHEALTHY %s (running=%s)", container_name, output
+        )
+        return False

--- a/dockfleet/health/scheduler.py
+++ b/dockfleet/health/scheduler.py
@@ -1,15 +1,31 @@
 import logging
 import threading
 import time
+from typing import Optional
+from dockfleet.cli.config import DockFleetConfig, HealthCheckConfig
+from dockfleet.health.checker import HealthChecker
 
+DEFAULT_INTERVAL_SECONDS = 30
 
 class HealthScheduler:
-#  Background scheduler that will periodically run health checks.
-    def __init__(self, interval_seconds: int = 30) -> None:
+    """
+    Background scheduler to periodically runs health checks
+    for services that have a healthcheck configured in DockFleetConfig.
+
+    Day 8 scope: only logs/prints healthy/unhealthy, no DB writes.
+    """
+    def __init__(
+        self,
+        config: DockFleetConfig,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+    ) -> None:
+        self.config = config
         self.interval_seconds = interval_seconds
-        self._stopped = True
-        self._thread: threading.Thread | None = None
+
+        self._stopped: bool = True
+        self._thread: Optional[threading.Thread] = None
         self._logger = logging.getLogger(__name__)
+        self._checker = HealthChecker()
 
     def start(self) -> None:
         # Start the background polling thread if it's not already running.
@@ -28,6 +44,7 @@ class HealthScheduler:
 
     def stop(self) -> None:
         # Signal the polling thread to stop and wait for it to finish.
+
         self._stopped = True
 
         if self._thread is not None and self._thread.is_alive():
@@ -37,11 +54,74 @@ class HealthScheduler:
             self._logger.info("HealthScheduler: thread stopped")
 
     def _poll(self) -> None:
-        # Main loop that will later run health checks.
+        """
+        Main loop to runs health checks in the background.
+
+        Day 8: read from in-memory config only, no DB writes.
+        """
         self._logger.info("HealthScheduler: poll loop started")
 
         while not self._stopped:
             self._logger.info("HealthScheduler: polling services...")
+
+            for name, svc_cfg in self.config.services.items():
+                hc: Optional[HealthCheckConfig] = svc_cfg.healthcheck
+
+                # Skip services without healthcheck
+                if hc is None:
+                    continue
+
+                ok = self._run_single_check(name, hc)
+                status_str = "HEALTHY" if ok else "UNHEALTHY"
+                self._logger.info("HealthScheduler: %s -> %s", name, status_str)
+
             time.sleep(self.interval_seconds)
 
         self._logger.info("HealthScheduler: poll loop exiting")
+
+    def _run_single_check(self, name: str, hc: HealthCheckConfig) -> bool:
+        # Run one health check based on its type and return True/False.
+ 
+        hc_type = hc.type.lower()
+
+        if hc_type == "http":
+            # Expect endpoint like "http://localhost:8000/health"
+            return self._checker.check_http(hc.endpoint)
+
+        if hc_type == "tcp":
+            # Expect endpoint like "localhost:8000"
+            host, port = self._split_host_port(hc.endpoint)
+            if host is None or port is None:
+                self._logger.warning(
+                    "HealthScheduler: invalid TCP endpoint for %s: %s",
+                    name,
+                    hc.endpoint,
+                )
+                return False
+            return self._checker.check_tcp(host, port)
+
+        if hc_type == "process":
+            # Convention: Docker container names use "dockfleet_{service_name}"
+            container_name = f"dockfleet_{name}"
+            return self._checker.check_process(container_name)
+
+        self._logger.warning(
+            "HealthScheduler: unknown healthcheck type for %s: %s",
+            name,
+            hc.type,
+        )
+        return False
+
+    def _split_host_port(self, endpoint: str) -> tuple[Optional[str], Optional[int]]:
+        # Helper to split 'host:port' strings safely.
+
+        if ":" not in endpoint:
+            return None, None
+
+        host, port_str = endpoint.rsplit(":", 1)
+        try:
+            port = int(port_str)
+        except ValueError:
+            return None, None
+
+        return host, port

--- a/docs/database/service table.md
+++ b/docs/database/service table.md
@@ -23,7 +23,7 @@ Table: services
 - ports_raw
   - type: TEXT
   - constraints: NULL allowed
-  - desc: Serialized ports list from config (e.g., '["8000:8000"]' or "8000:8000,9000:9000").
+  - desc: Serialized ports list from config (e.g., "8000:8000" or "8000:8000,9000:9000").
 
 - healthcheck_raw
   - type: TEXT
@@ -33,7 +33,8 @@ Table: services
 - status
   - type: TEXT
   - constraints: NOT NULL
-  - desc: Current health status (e.g., "running", "unhealthy", "restarting", "stopped").
+  - desc: Current service status (e.g., "running", "unhealthy", "restarting", "stopped").
+  - note: Seed time: status is set to "stopped". Unknown / unhealthy states will only be used once the health engine is implemented in Week 2.
 
 - restart_count
   - type: INTEGER

--- a/docs/health_engine_design.md
+++ b/docs/health_engine_design.md
@@ -1,10 +1,12 @@
 ## 1. Responsibilities (Health & State Engine)
 
-- Track per-service health status (running / unhealthy / restarting / stopped).
+- Track per-service status (running / unhealthy / restarting / stopped).
 - Auto-restart on failures (based on restart policy).
 - Store restart history and basic crash reasons.
 - Stay in sync with YAML config (`DockFleetConfig` / `ServiceConfig`).
 - Expose a simple API so CLI (`dockfleet seed`) and orchestrator (`up(config)`) can hook in easily.
+
+> Seed time: status is set to "stopped". Unknown / unhealthy states are not used until the health engine is implemented in Week 2.
 
 ## 2. Config → Service mapping
 
@@ -12,39 +14,52 @@ Given `DockFleetConfig.services: Dict[str, ServiceConfig]`:
 
 - `name` (dict key) → `Service.name`
 - `ServiceConfig.image` → `Service.image`
-- `ServiceConfig.restart` → `Service.restart_policy` (values: `always`, `on-failure`, `never`)
-- `ServiceConfig.ports` → `Service.ports_raw` (serialized list, e.g. JSON or comma-separated)
-- `ServiceConfig.healthcheck` → `Service.healthcheck_raw` (serialized `HealthCheckConfig`)
-- Runtime fields set by health engine:
-  - `Service.status` → `"unknown"` / `"pending"` initially, later `"running"`, `"unhealthy"`, etc.
-  - `Service.restart_count` → `0` initially.
-  - `Service.last_health_check` → `NULL` initially.
-  - `Service.last_failure_reason` → `NULL` initially.
+- `ServiceConfig.restart` → `Service.restart_policy`
+  - allowed values: `always`, `on-failure`, `never`
+- `ServiceConfig.ports` → `Service.ports_raw` (serialized list, e.g. comma-separated string `"8000:8000,9000:9000"`).
+- `ServiceConfig.healthcheck` → `Service.healthcheck_raw` (serialized `HealthCheckConfig` to JSON).
 
+Runtime fields:
+
+- `Service.status`
+  - seed time: `"stopped"` (service defined but not yet started).
+  - later: `"running"`, `"unhealthy"`, `"restarting"`, `"stopped"` updated by orchestrator + health engine.
+- `Service.restart_count`
+  - `0` initially.
+- `Service.last_health_check`
+  - `NULL` initially, set by health engine poll loop.
+- `Service.last_failure_reason`
+  - `NULL` initially, set when health checks fail.
 
 ## 3. Public health-engine functions
 
-### 3.1 from_config(config: DockFleetConfig) -> list[Service]
+### 3.1 `services_from_config(config: DockFleetConfig) -> list[Service]`
 
 - Input: parsed YAML config (`DockFleetConfig`).
 - Output: list of `Service` objects (NOT yet written to DB).
 - Steps:
   - Loop over `config.services.items()` (`name`, `ServiceConfig`).
   - Map config fields to `Service` fields using the mapping above.
-  - Set runtime defaults (`status`, `restart_count`, `last_health_check`, `last_failure_reason`).
+  - Set runtime defaults:
+
+    - `status = "stopped"`  
+    - `restart_count = 0`  
+    - `last_health_check = None`  
+    - `last_failure_reason = None`
+
   - Return the list of `Service` instances.
 
-### 3.2 seed_services(config: DockFleetConfig, session: Session) -> None
+### 3.2 `seed_services(config: DockFleetConfig, session: Session) -> None`
 
 - Input: `DockFleetConfig` + SQLModel `Session`.
 - Behavior:
-  - For each `Service` from `from_config(config)`:
-    - If a row with the same `Service.name` already exists in DB → leave as is.
-    - If it does not exist → insert a new row.
+  - For each `Service` from `services_from_config(config)`:
+    - If a row with the same `Service.name` already exists in DB → leave it as is (do not overwrite status or counters).
+    - If it does not exist → insert a new row with `status="stopped"` and other defaults.
 - Idempotent:
   - Safe to call multiple times with the same config without creating duplicates.
 
-### 3.3 bootstrap_from_config(config: DockFleetConfig) -> None
+### 3.3 `bootstrap_from_config(config: DockFleetConfig) -> None`
 
 - Input: in-memory `DockFleetConfig` object.
 - Behavior:
@@ -52,10 +67,10 @@ Given `DockFleetConfig.services: Dict[str, ServiceConfig]`:
   - Opens a `Session(engine)`.
   - Calls `seed_services(config, session)` to sync `Service` rows with YAML.
 - Intended usage:
-  - Orchestrator can call this before or during `up(config)` if it wants automatic seeding.
+  - Orchestrator can call this at the start of `up(config)` so DB is always seeded before containers start.
   - Tests and scripts can call this directly.
 
-### 3.4 bootstrap_from_path(path: str = "examples/dockfleet.yaml") -> None
+### 3.4 `bootstrap_from_path(path: str = "examples/dockfleet.yaml") -> None`
 
 - Input: path to a DockFleet YAML file.
 - Behavior:
@@ -64,3 +79,11 @@ Given `DockFleetConfig.services: Dict[str, ServiceConfig]`:
 - Intended usage:
   - `dockfleet seed` CLI command (Typer) should call this function.
   - `python -m dockfleet.health.seed` currently uses this for local dev.
+
+## 4. Health engine + orchestrator attachment (plan)
+
+- HealthScheduler will periodically read all Service rows from SQLite using a read-only Session.
+- For each service, it will decode `healthcheck_raw` (HTTP/TCP/process) and run the appropriate check.
+- On success, it will update `Service.status` to `running` and refresh `last_health_check`.
+- On failure, it will increment `restart_count`, set `last_failure_reason`, and insert a `RestartEvent` row.
+- After N consecutive failures (e.g. 3), it will call an orchestrator restart API (e.g. `restart_service(name)`) instead of talking to Docker directly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 pyyaml
 pytest
 typer
+requests

--- a/tests/test_orchestrator_db_sync.py
+++ b/tests/test_orchestrator_db_sync.py
@@ -1,0 +1,51 @@
+from sqlmodel import Session, select
+
+from dockfleet.health.models import init_db, Service, engine
+from dockfleet.health.services import seed_services
+from dockfleet.cli.config import load_config, DockFleetConfig
+from dockfleet.core.orchestrator import Orchestrator
+
+
+def test_orchestrator_updates_db_status(tmp_path):
+    """
+    End-to-end check of DB sync:
+    - init DB + seed services from YAML
+    - orchestrator.up() runs (some services may fail to start)
+    - orchestrator.down() stops running ones
+    """
+
+    init_db()
+
+    config_path = "examples/dockfleet.yaml"
+    config: DockFleetConfig = load_config(config_path)
+
+    with Session(engine) as session:
+        seed_services(config, session)
+
+    # Baseline: after seed, all services have some initial status
+    with Session(engine) as session:
+        services = session.exec(select(Service)).all()
+        assert len(services) > 0
+
+    orch = Orchestrator(config)
+    orch.up()
+
+    # After up:
+    # - redis (valid image) should be 'running'
+    # - api (missing image) should remain 'stopped' (or whatever baseline was)
+    with Session(engine) as session:
+        services = {svc.name: svc for svc in session.exec(select(Service)).all()}
+
+        # redis successfully pulled & started according to stdout
+        assert services["redis"].status == "running"
+
+        # api failed to start, so it should NOT be 'running'
+        assert services["api"].status != "running"
+
+    orch.down()
+
+    # After down: all services should end up 'stopped'
+    with Session(engine) as session:
+        services = session.exec(select(Service)).all()
+        for svc in services:
+            assert svc.status == "stopped"

--- a/tests/test_run_health_scheduler.py
+++ b/tests/test_run_health_scheduler.py
@@ -1,0 +1,36 @@
+import logging
+import time
+
+from dockfleet.cli.config import load_config, DockFleetConfig
+from dockfleet.health.scheduler import HealthScheduler
+
+
+def test_manual_health_scheduler_run():
+    """
+    Manual-style test to visually verify HealthScheduler logs
+    It will:
+    - load examples/dockfleet.yaml
+    - start scheduler with 10s interval
+    - run for ~30 seconds
+    """
+    logging.basicConfig(level=logging.INFO)
+
+    # 1) Load config from sample YAML
+    config_path = "examples/dockfleet.yaml"
+    config: DockFleetConfig = load_config(config_path)
+
+    # 2) Create scheduler (10-second poll interval)
+    scheduler = HealthScheduler(config=config, interval_seconds=10)
+
+    # 3) Start scheduler
+    scheduler.start()
+
+    # 4) Let it run for a short window so you can see logs
+    time.sleep(30)
+
+    # 5) Stop scheduler
+    scheduler.stop()
+
+
+# pytest tests/test_run_health_scheduler.py -s 
+# use this for running it


### PR DESCRIPTION
- Sync orchestrator up()/down() with SQLite Service.status via mark_service_running/stopped, so DB reflects container lifecycle.
- Add bootstrap_from_config path to seed services from dockfleet.yaml before orchestration runs, keeping DB and config in sync.
- Introduce HealthChecker for HTTP/TCP/Docker‑process probes, returning simple boolean health signals without touching DB.
- Upgrade HealthScheduler to use in‑memory DockFleetConfig + HealthChecker in a background thread, logging per‑service health results on an interval (no writes yet).
- Document health engine plan and service status lifecycle (seed → stopped, up → running, down → stopped) to prepare Week 2 auto‑restart work.