### PR TITLE
feat(health): add failure streak logic and auto-restart wiring

### DIFF
--- a/dockfleet/health/scheduler.py
+++ b/dockfleet/health/scheduler.py
@@ -2,9 +2,12 @@ import logging
 import threading
 import time
 from typing import Optional
+from sqlmodel import Session, select
 from dockfleet.cli.config import DockFleetConfig, HealthCheckConfig
 from dockfleet.health.checker import HealthChecker
-from dockfleet.health.status import update_service_health
+from dockfleet.health.status import update_service_health, needs_restart
+from dockfleet.health.models import Service, engine
+from dockfleet.core.orchestrator import handle_unhealthy_service
 
 DEFAULT_INTERVAL_SECONDS = 30
 
@@ -15,6 +18,7 @@ class HealthScheduler:
     - Run HTTP/TCP/process checks via HealthChecker
     - Log results
     - Persist status / last_health_check / restart_count in DB
+    - Signal orchestrator when auto-restart thresholds are hit
     """
     def __init__(
         self,
@@ -32,7 +36,6 @@ class HealthScheduler:
         self._checker: HealthChecker = checker or HealthChecker()
 
     def start(self) -> None:
-
         # Start the background polling thread if it's not already running.
         if self._thread is not None and self._thread.is_alive():
             return
@@ -48,7 +51,6 @@ class HealthScheduler:
         self._logger.info("HealthScheduler: started background thread")
 
     def stop(self) -> None:
-
         # Signal the polling thread to stop and wait for it to finish.
         self._stopped = True
 
@@ -63,16 +65,19 @@ class HealthScheduler:
 
     def _poll(self) -> None:
         """
-        Main loop to runs health checks in the background.
+        Main loop to run health checks in the background.
 
         Uses in-memory DockFleetConfig to know which services to check,
         and writes results into the Service table via update_service_health.
+        Also checks for services that have hit the auto-restart threshold
+        and delegates restart handling to the orchestrator layer.
         """
         self._logger.info("HealthScheduler: poll loop started")
 
         while not self._stopped:
             self._logger.info("HealthScheduler: polling services...")
 
+            # 1) Run health checks and update DB state
             for name, svc_cfg in self.config.services.items():
                 hc: Optional[HealthCheckConfig] = svc_cfg.healthcheck
 
@@ -100,9 +105,57 @@ class HealthScheduler:
                         exc,
                     )
 
+            # 2) After updating DB, see which services now need restart
+            try:
+                self._check_and_trigger_restarts()
+            except Exception as exc:  # pragma: no cover (defensive)
+                # Even if restart logic has a bug, do not kill scheduler loop
+                self._logger.error(
+                    "HealthScheduler: error while evaluating auto-restarts: %s",
+                    exc,
+                )
+
             time.sleep(self.interval_seconds)
 
         self._logger.info("HealthScheduler: poll loop exiting")
+
+    def _check_and_trigger_restarts(self) -> None:
+        """
+        Read services from DB and for any that satisfy needs_restart,
+        delegate to orchestrator via handle_unhealthy_service.
+
+        This keeps health logic (DB + decision) on the health side,
+        and actual container restarts on the orchestrator side.
+        """
+        with Session(engine) as session:
+            services = session.exec(select(Service)).all()
+
+        for svc in services:
+            if not needs_restart(svc):
+                continue
+
+            self._logger.info(
+                "HealthScheduler: auto-restart candidate detected: %s "
+                "(policy=%s, consecutive_failures=%d)",
+                svc.name,
+                svc.restart_policy,
+                svc.consecutive_failures,
+            )
+            """"
+            Delegate to orchestrator; orchestrator is responsible for:
+             - performing the restart
+             - resetting consecutive_failures in DB on success
+             - logging a RestartEvent and failure reason if needed
+            """
+
+            try:
+                handle_unhealthy_service(svc, self.config)
+            except Exception as exc:  # pragma: no cover (defensive)
+                self._logger.error(
+                    "HealthScheduler: auto-restart failed for %s: %s",
+                    svc.name,
+                    exc,
+                )
 
     def _run_single_check(self, name: str, hc: HealthCheckConfig) -> bool:
         # Run one health check based on its type and return True/False.

--- a/dockfleet/health/status.py
+++ b/dockfleet/health/status.py
@@ -14,27 +14,23 @@ def _update_status(
     new_status: str,
     set_last_health: bool = False,
 ) -> None:
-    # 1) Session open with context manager
+    """Low-level helper to flip status for a service by name."""
     with Session(engine) as session:
-        # 2) Service row find karo by name
         existing = session.exec(
             select(Service).where(Service.name == name)
         ).one_or_none()
 
-        # 3) Not found → silently return (ya warning log)
         if existing is None:
             print(
                 f"[status] Service '{name}' not found in DB, skipping status update"
             )
             return
 
-        # 4) Status change + optional last_health_check
         existing.status = new_status
 
         if set_last_health:
             existing.last_health_check = datetime.utcnow()
 
-        # 5) Commit the change
         session.add(existing)
         session.commit()
 
@@ -75,7 +71,7 @@ def update_service_health(
             svc.status = "running"
             # if we were failing before, reset the streak
             svc.consecutive_failures = 0
-            # restart_count unchanged here 
+            # restart_count unchanged here
         else:
             svc.status = "unhealthy"
             svc.restart_count += 1
@@ -85,3 +81,22 @@ def update_service_health(
 
         session.add(svc)
         session.commit()
+
+def needs_restart(service: Service) -> bool:
+    """
+    Decide if a service should be restarted based on failure streak
+    and restart_policy.
+    Rules:
+    - If restart_policy == "never" -> never restart.
+    - Otherwise, restart if consecutive_failures >= 3.
+    """
+    # policies: "always", "on-failure", "never"
+    if service.restart_policy == "never":
+        return False
+
+    if service.consecutive_failures < 3:
+        return False
+
+    # For "always" and "on-failure", once we have 3 consecutive
+    # unhealthy checks, this service is eligible for restart.
+    return True

--- a/tests/test_needs_restart.py
+++ b/tests/test_needs_restart.py
@@ -1,0 +1,89 @@
+import pytest
+from sqlmodel import Session, select
+
+from dockfleet.health.models import Service, init_db, engine
+from dockfleet.health.status import update_service_health, needs_restart
+
+
+def _create_service(
+    name: str = "api",
+    restart_policy: str = "always",
+) -> Service:
+    svc = Service(
+        name=name,
+        image="dummy-image",
+        restart_policy=restart_policy,
+        status="running",
+    )
+    with Session(engine) as session:
+        session.add(svc)
+        session.commit()
+    return svc
+
+
+def _get_service(name: str) -> Service:
+    with Session(engine) as session:
+        return session.exec(
+            select(Service).where(Service.name == name)
+        ).one()
+
+
+def setup_function() -> None:
+    """
+    Simple per-test reset: drop + recreate all tables.
+
+    NOTE: If your project already has a shared test_db fixture that
+    handles this, prefer using that instead of setup_function.
+    """
+    # Recreate schema fresh for each test
+    # (SQLModel doesn't have drop_all shortcut, so easiest in tests is
+    # to recreate the file or use a temp DB; adapt if you already have
+    # a better pattern in your suite.)
+    init_db()
+
+
+def test_needs_restart_after_three_failures_with_always_policy() -> None:
+    init_db()
+    _create_service(name="svc1", restart_policy="always")
+
+    # simulate 3 consecutive unhealthy checks
+    update_service_health("svc1", is_healthy=False, reason="fail 1")
+    update_service_health("svc1", is_healthy=False, reason="fail 2")
+    update_service_health("svc1", is_healthy=False, reason="fail 3")
+
+    svc = _get_service("svc1")
+
+    assert svc.consecutive_failures == 3
+    assert svc.status == "unhealthy"
+    assert needs_restart(svc) is True
+
+
+def test_needs_restart_false_before_threshold() -> None:
+    init_db()
+    _create_service(name="svc2", restart_policy="always")
+
+    # only 2 failures -> should NOT trigger restart yet
+    update_service_health("svc2", is_healthy=False, reason="fail 1")
+    update_service_health("svc2", is_healthy=False, reason="fail 2")
+
+    svc = _get_service("svc2")
+
+    assert svc.consecutive_failures == 2
+    assert svc.status == "unhealthy"
+    assert needs_restart(svc) is False
+
+
+def test_needs_restart_respects_never_policy() -> None:
+    init_db()
+    _create_service(name="svc3", restart_policy="never")
+
+    # even with 3 failures, never policy must block restart
+    update_service_health("svc3", is_healthy=False, reason="fail 1")
+    update_service_health("svc3", is_healthy=False, reason="fail 2")
+    update_service_health("svc3", is_healthy=False, reason="fail 3")
+
+    svc = _get_service("svc3")
+
+    assert svc.consecutive_failures == 3
+    assert svc.status == "unhealthy"
+    assert needs_restart(svc) is False


### PR DESCRIPTION
- Added consecutive_failures tracking in Service model and implemented update_service_health to maintain status, streak, and restart counters in SQLite.
- Introduced needs_restart(service) helper that encodes “3 consecutive failures + restart policy (always/on-failure, not never)” as the auto‑restart decision rule.
- Created test_needs_restart.py to simulate unhealthy sequences and verify both the threshold behaviour and respect for restart_policy="never".
- Extended HealthScheduler to, after each polling cycle, read services from DB, evaluate needs_restart, and call orchestrator’s handle_unhealthy_service(service, config) for auto‑restart candidates, guarded with defensive logging and try/except.