### PR TITLE
feat(orchestrator): add auto-restart handler with crash marking and restart events

### DIFF
--- a/dockfleet/core/orchestrator.py
+++ b/dockfleet/core/orchestrator.py
@@ -1,9 +1,20 @@
 from dockfleet.core.docker import DockerManager
 from dockfleet.health.status import (
     mark_service_running,
-    mark_service_stopped
+    mark_service_stopped,
+    mark_restart_successful,
+    record_restart_event
 )
+
+from dockfleet.health.models import Service, engine
 from dockfleet.health.seed import bootstrap_from_config
+import logging
+from sqlmodel import Session, select
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
 
 class Orchestrator:
 
@@ -33,11 +44,11 @@ class Orchestrator:
 
             mark_service_running(name)
 
-            print(f" Started service: {name}")
+            print(f"Started service: {name}")
 
         except Exception as e:
 
-            print(f" Failed to start {name}")
+            print(f"Failed to start {name}")
             print(e)
 
     def stop_service(self, name):
@@ -51,25 +62,110 @@ class Orchestrator:
 
             mark_service_stopped(name)
 
-            print(f" Stopped service: {name}")
+            print(f"Stopped service: {name}")
 
         except Exception as e:
 
-            print(f" Failed to stop {name}")
+            print(f"Failed to stop {name}")
             print(e)
 
-    def restart(self, service_name):
+    def restart_service(self, service_name: str, config=None) -> bool:
 
-        if service_name not in self.config.services:
-            print(f"Service {service_name} not found")
+        config = config or self.config
+        
+        if service_name not in config.services:
+            logger.warning(f"Service {service_name} not found")
+            return False
+        
+        import subprocess
+        container_name = self.container_name(service_name)
+        try:
+            result = subprocess.run(
+                ["docker", "ps", "--filter", f"name={container_name}", "--format", "{{.Names}}"],
+                capture_output=True, text=True, timeout=5
+            )
+            if not result.stdout.strip():
+                logger.info(f"{service_name} not running, skipping restart")
+                return False
+        except:
+            logger.warning(f"Cannot check {service_name}, skipping")
+            return False
+        
+        svc = config.services[service_name]
+        print(f"Restarting container: {service_name}")
+        
+        try:
+            # Stop container
+            self.stop_service(service_name)
+            
+            self._increment_restart_count(service_name)
+            
+            # Start fresh
+            self.start_service(service_name, svc)
+            logger.info(f"{service_name} restarted (restart_count incremented)")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Container restart failed: {e}")
+            return False
+
+    def _increment_restart_count(self, service_name: str) -> None:
+        try:
+            with Session(engine) as session:
+                svc = session.exec(
+                    select(Service).where(Service.name == service_name)
+                ).one_or_none()
+                
+                if svc:
+                    svc.restart_count = (svc.restart_count or 0) + 1
+                    session.add(svc)
+                    session.commit()
+                    logger.info(f"DB: {service_name} restart_count={svc.restart_count}")
+                else:
+                    logger.warning(f"Service {service_name} not in DB")
+                    
+        except Exception as e:
+            logger.error(f"DB increment failed for {service_name}: {e}")
+
+    def handle_unhealthy_service(self, service_name: str, config=None, reason: str = "health failure") -> None:
+        
+        config = config or self.config  
+        logger.info("Auto-restart: %s (%s)", service_name, reason)
+
+        try:
+            success = self.restart_service(service_name)
+        except Exception as exc:
+            logger.error("CRITICAL restart error %s: %s", service_name, exc)
+            self._mark_restart_failed(service_name, str(exc))
             return
+        
+        if not success:
+            logger.error("restart_service failed %s", service_name)
+            self._mark_restart_failed(service_name, "restart_service returned False")
+            return
+        
+        # SUCCESS 
+        logger.info("%s auto-restarted", service_name)
+        mark_restart_successful(service_name)
+        
+        # Record event
+        with Session(engine) as session:
+            svc = session.exec(select(Service).where(Service.name == service_name)).one_or_none()
+            if svc:
+                record_restart_event(svc, reason)
+            else:
+                logger.warning("Service %s not found after restart", service_name)
 
-        svc = self.config.services[service_name]
+    def _mark_restart_failed(self, service_name: str, reason: str) -> None:
 
-        print(f"Restarting service: {service_name}")
-
-        self.stop_service(service_name)
-        self.start_service(service_name, svc)
+        with Session(engine) as session:
+            svc = session.exec(select(Service).where(Service.name == service_name)).one_or_none()
+            if svc:
+                svc.status = "crashed"
+                svc.last_failure_reason = f"auto-restart failed: {reason}"
+                session.add(svc)
+                session.commit()
+                logger.error(" %s marked CRASHED: %s", service_name, reason)
 
     def up(self):
         print("Starting services...\n")

--- a/dockfleet/health/status.py
+++ b/dockfleet/health/status.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 from sqlmodel import Session, select
-from .models import Service, engine
+from .models import Service, RestartEvent, engine
 
 def mark_service_running(name: str) -> None:
     _update_status(name, "running", set_last_health=True)
@@ -84,19 +84,54 @@ def update_service_health(
 
 def needs_restart(service: Service) -> bool:
     """
-    Decide if a service should be restarted based on failure streak
-    and restart_policy.
+    Decide if a service should be auto-restarted.
     Rules:
-    - If restart_policy == "never" -> never restart.
-    - Otherwise, restart if consecutive_failures >= 3.
+    - At least 3 consecutive health check failures.
+    - restart_policy must be "always" or "on-failure".
+    - restart_policy == "never" is a hard block.
     """
-    # policies: "always", "on-failure", "never"
-    if service.restart_policy == "never":
-        return False
-
     if service.consecutive_failures < 3:
         return False
 
-    # For "always" and "on-failure", once we have 3 consecutive
-    # unhealthy checks, this service is eligible for restart.
+    if service.restart_policy not in {"always", "on-failure"}:
+        return False
+
     return True
+
+def record_restart_event(service: Service, reason: str) -> None:
+    """
+    Store a simple restart event for later crash analytics.
+    Example reason: "3_failed_health_checks".
+    """
+    # No DB lookup needed; we already have the Service instance.
+    event = RestartEvent(
+        service_id=service.id,
+        restarted_at=datetime.utcnow(),
+        reason=reason,
+        previous_status=service.status,
+        new_status="running",  # intended post-restart status
+    )
+
+    with Session(engine) as session:
+        session.add(event)
+        session.commit()
+
+def mark_restart_successful(service_name: str) -> None:
+    """
+    Called by orchestrator after a successful auto-restart.
+    Resets consecutive_failures and marks status as running.
+    """
+    with Session(engine) as session:
+        svc = session.exec(
+            select(Service).where(Service.name == service_name)
+        ).one_or_none()
+
+        if svc is None:
+            print(f"[restart] Service '{service_name}' not found in DB")
+            return
+
+        svc.consecutive_failures = 0
+        svc.status = "running"
+
+        session.add(svc)
+        session.commit()


### PR DESCRIPTION
• Add idempotent restart_service(name, config): docker ps check + skip missing containers
• Add DB restart_count increment via increment_restart_count() helper  
• Complete handle_unhealthy_service() with health helpers (mark_restart_successful, record_restart_event)
• Add _mark_restart_failed() for crash state tracking
• Full HealthScheduler integration ready (needs_restart → handle_unhealthy_service flow)