### PR TITLE
Wire health-dev CLI to SQLite-backed health scheduler

### DIFF
--- a/dockfleet/cli/main.py
+++ b/dockfleet/cli/main.py
@@ -1,13 +1,17 @@
-import typer
 import sys
 import subprocess
 from pathlib import Path
+import logging
+import time
+from dockfleet.health.status import update_service_health
+import typer
 from pydantic import ValidationError
-
 from dockfleet.cli.config import load_config
 from dockfleet.core.orchestrator import Orchestrator
 from dockfleet.health.seed import bootstrap_from_path
 from dockfleet.health.scheduler import HealthScheduler
+from dockfleet.health.models import sqlite_file_name  # if you expose this; otherwise hardcode "dockfleet.db"
+
 
 app = typer.Typer(help="DockFleet CLI - Manage Docker services from YAML configuration")
 
@@ -36,15 +40,15 @@ def validate(path: Path = typer.Argument("dockfleet.yaml")):
 
 @app.command()
 def seed(path: Path = typer.Argument("dockfleet.yaml")):
-   """Initialize the service database and register services from the configuration."""
-   try:
+    """Initialize the service database and register services from the configuration."""
+    try:
         typer.echo(f"Seeding services from {path}...")
 
         bootstrap_from_path(str(path))
 
         typer.echo("✓ Seeding complete")
 
-   except Exception as e:
+    except Exception as e:
         typer.echo(f"Seeding failed: {e}")
         raise typer.Exit(code=1)
 
@@ -114,7 +118,7 @@ def doctor():
             ["docker", "--version"],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
 
         typer.echo(f"Docker detected: {result.stdout.strip()}")
@@ -123,18 +127,37 @@ def doctor():
     except Exception:
         typer.echo("✗ Docker not found or not running")
         raise typer.Exit(code=1)
-@app.command("health-dev")
-def health_dev(path: Path = typer.Argument("dockfleet.yaml")):
-    """
-    Developer command to run the health check scheduler manually.
-    Press Ctrl+C to stop.
-    """
 
+
+@app.command("health-dev")
+def health_dev(
+    path: Path = typer.Argument("dockfleet.yaml"),
+    once: bool = typer.Option(
+        False,
+        "--once",
+        help="Run a single health pass and exit (useful for tests).",
+    ),
+):
+    """
+    Developer command to run the health check scheduler backed by SQLite DB.
+
+    - Initializes DB + seeds services if needed.
+    - Runs HealthScheduler which writes status into the Service table.
+    - By default runs in a loop until Ctrl+C; with --once runs one cycle and exits.
+    """
     try:
         typer.echo("Starting DockFleet health check scheduler (DEV MODE)")
-        typer.echo("Press Ctrl+C to stop\n")
+        typer.echo("Press Ctrl+C to stop\n" if not once else "Running a single health pass\n")
 
         config = load_config(path)
+
+        # Ensure DB and Service rows are present
+        typer.echo(f"Bootstrapping health DB from {path} ...")
+        bootstrap_from_path(str(path))
+
+        # Print DB location for debugging
+        db_path = sqlite_file_name if "sqlite_file_name" in globals() else "dockfleet.db"
+        typer.echo(f"Health engine using SQLite DB at: {db_path}\n")
 
         # check if any service has healthcheck defined
         services_with_health = [
@@ -148,11 +171,31 @@ def health_dev(path: Path = typer.Argument("dockfleet.yaml")):
 
         scheduler = HealthScheduler(config)
 
+        if once:
+            scheduler._logger = logging.getLogger(__name__)
+            for name, svc_cfg in config.services.items():
+                hc = svc_cfg.healthcheck
+                if hc is None:
+                    continue
+                ok = scheduler._run_single_check(name, hc)
+                status_str = "HEALTHY" if ok else "UNHEALTHY"
+                typer.echo(f"[once] {name} -> {status_str}")
+                update_service_health(
+                    name,
+                    ok,
+                    reason=None if ok else "health check failed",
+                )
+                scheduler._handle_post_health(name)
+            typer.echo("Single health pass complete.")
+        return
+
+
+        # Normal long-running mode
         scheduler.start()
 
         try:
             while True:
-                pass
+                time.sleep(1)
         except KeyboardInterrupt:
             typer.echo("\nStopping health scheduler...")
             scheduler.stop()
@@ -160,6 +203,7 @@ def health_dev(path: Path = typer.Argument("dockfleet.yaml")):
     except Exception as e:
         typer.echo(f"Health scheduler failed: {e}")
         raise typer.Exit(code=1)
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
Adds `dockfleet health-dev` CLI command integrated with the SQLite-backed health engine.

Changes:

* Bootstraps health database using configuration file
* Runs `HealthScheduler` for continuous health monitoring
* Adds `--once` mode for running a single health check cycle
* Prints health status for services with configured health checks

This enables developers to locally test the health monitoring system and verify service status updates stored in SQLite.
