### PR TITLE
log metadata groundwork and packaging cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Thumbs.db
 # Coverage
 .coverage
 htmlcov/
+
+# Python packaging / build artifacts
+dockfleet.egg-info/

--- a/dockfleet/health/models.py
+++ b/dockfleet/health/models.py
@@ -1,8 +1,10 @@
 from sqlmodel import Field, Session, SQLModel, create_engine
 from datetime import datetime
 
-# Service table model 
-# fields: id, name, images, restart_policy, ports_raw, healthcheck_raw, status, restart_count, last_health_check, last_failure_reason, consecutive_failures
+"""
+Service table model
+fields: id, name, image, restart_policy, ports_raw, healthcheck_raw, status, restart_count, last_health_check, last_failure_reason, consecutive_failures
+"""
 class Service(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(nullable=False, unique=True)
@@ -25,6 +27,29 @@ class RestartEvent(SQLModel, table=True):
     reason: str = Field(nullable=False)
     previous_status: str | None = Field(default=None)
     new_status: str | None = Field(default=None)
+
+# LogEvent table model (log metadata skeleton)
+# fields: id, service_id, service_name, created_at, level, message, source
+class LogEvent(SQLModel, table=True):
+    """
+    Lightweight log metadata row for future log aggregation / crash analytics.
+    Raw Docker logs will still be streamed separately; this table stores
+    small, query-friendly summaries (who, when, what, where-from).
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+
+    service_id: int = Field(nullable=False, foreign_key="service.id")
+    service_name: str = Field(nullable=False)
+
+    created_at: datetime = Field(nullable=False)
+
+    # Optional metadata fields
+    level: str | None = Field(default=None)  # e.g. "INFO", "WARN", "ERROR"
+    message: str | None = Field(default=None)  # short summary / first line
+    source: str | None = Field(
+        default=None
+    )  # e.g. "docker-logs", "scheduler", "orchestrator"
 
 # init_db() function
 # work: engine + tables create

--- a/docs/logging_design.md
+++ b/docs/logging_design.md
@@ -1,0 +1,37 @@
+# Log metadata design 
+Goal: central place to index logs for crash analytics and the dashboard, without
+storing full raw Docker logs in SQLite.
+
+## LogEvent schema
+
+We introduced a `LogEvent` table:
+
+- `service_id` + `service_name` – which service the log belongs to.
+- `created_at` – when this log line/summary was produced.
+- `level` – optional level (`INFO`, `WARN`, `ERROR`, etc.).
+- `message` – short summary or first line of the log.
+- `source` – where this came from (`docker-logs`, `scheduler`, `orchestrator`).
+
+## How logs can be written
+
+Two main writers can populate `LogEvent`:
+
+1. **SSE logs endpoint (Khushi’s part)**  
+   - Backend wraps `docker logs -f` per service.  
+   - As it streams lines to the dashboard over SSE, it can *optionally* sample
+     or aggregate lines and insert `LogEvent` rows (e.g. first error line,
+     summary of last N lines, etc.).
+
+2. **Side processes / system components**  
+   - Health scheduler and orchestrator can record important events:
+     - auto-restart attempts
+     - crashes (`status="crashed"`)
+     - repeated failures  
+   - Instead of writing full logs, they call a helper like
+     `record_log_event(service, level="ERROR", message="auto-restart failed")`.
+
+Frontend / dashboard can then:
+
+- Query recent `LogEvent` rows per service for a "Recent events" sidebar.
+- Build crash analytics (e.g. “most unstable services”, timeline of errors) from
+  this metadata, while still using live SSE for full log streaming.


### PR DESCRIPTION
- Introduced a LogEvent SQLModel in dockfleet/health/models.py to store lightweight log metadata for future log aggregation and crash analytics.
  - Fields include service_id, service_name, created_at, level, message, and source, giving us a structured way to index important events while still streaming full Docker logs separately.

- Documented the future logging design in docs/logging_design.md, outlining how Week 3 features (SSE log streaming, dashboard, side processes) can write sampled/summarized log metadata into SQLite via LogEvent.

- Updated .gitignore and repo state to ignore Python packaging/build artifacts such as *.egg-info, ensuring that dockfleet.egg-info/ created by pip install -e . stays local and does not pollute version control.