### PR TITLE
Improve health-dev CLI output with timestamps and add health monitoring docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ pip install -r requirements.txt
 
 This will install FastAPI, Typer, SQLModel/SQLAlchemy, and other libraries used by Dockfleet.
 
+
+
+### Install CLI locally
+
+DockFleet CLI (`dockfleet ...` commands) is provided by this repository itself.  
+For development, install it in editable mode inside your virtual environment.
+
+from project root, with venv activated
+
+```
+pip install -e .
+```
+
 ---
 
 #### Run Dashboard
@@ -236,6 +249,37 @@ dockfleet down examples/dockfleet.yaml
 ```
 
 Stops and removes all containers defined in the configuration.
+
+---
+
+## Health Monitoring
+
+DockFleet includes a built-in **health monitoring engine** that continuously checks the status of services and stores results in a SQLite database.
+
+Supported health checks:
+
+- **HTTP checks** – verify API endpoints respond correctly
+
+- **TCP checks** – confirm a port is reachable
+
+- **Process checks** – ensure containers are running
+
+You can run the health monitor using the CLI.
+
+Example:
+
+```
+python -m dockfleet.cli.main health-dev examples/dockfleet.yaml --once
+```
+
+Example output:
+
+```
+[2026-03-11 21:49:20] api: healthy  
+[2026-03-11 21:49:20] redis: healthy
+```
+
+Health results are stored in SQLite and will later be used by DockFleet to trigger automatic service recovery.
 
 ---
 

--- a/dockfleet/cli/main.py
+++ b/dockfleet/cli/main.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 import logging
 import time
+from datetime import datetime
 from dockfleet.health.status import update_service_health
 import typer
 from pydantic import ValidationError
@@ -10,14 +11,12 @@ from dockfleet.cli.config import load_config
 from dockfleet.core.orchestrator import Orchestrator
 from dockfleet.health.seed import bootstrap_from_path
 from dockfleet.health.scheduler import HealthScheduler
-from dockfleet.health.models import sqlite_file_name  # if you expose this; otherwise hardcode "dockfleet.db"
-
+from dockfleet.health.models import sqlite_file_name  
 
 app = typer.Typer(help="DockFleet CLI - Manage Docker services from YAML configuration")
 
 validate_app = typer.Typer()
 app.add_typer(validate_app, name="validate")
-
 
 @validate_app.callback(invoke_without_command=True)
 def validate(path: Path = typer.Argument("dockfleet.yaml")):
@@ -37,7 +36,6 @@ def validate(path: Path = typer.Argument("dockfleet.yaml")):
         typer.echo(f"Unexpected error: {e}")
         raise typer.Exit(code=1)
 
-
 @app.command()
 def seed(path: Path = typer.Argument("dockfleet.yaml")):
     """Initialize the service database and register services from the configuration."""
@@ -51,7 +49,6 @@ def seed(path: Path = typer.Argument("dockfleet.yaml")):
     except Exception as e:
         typer.echo(f"Seeding failed: {e}")
         raise typer.Exit(code=1)
-
 
 @app.command()
 def up(path: Path = typer.Argument("dockfleet.yaml")):
@@ -70,7 +67,6 @@ def up(path: Path = typer.Argument("dockfleet.yaml")):
         typer.echo(f"Error starting services: {e}")
         raise typer.Exit(code=1)
 
-
 @app.command()
 def down(path: Path = typer.Argument("dockfleet.yaml")):
     """Stop and remove all containers managed by DockFleet."""
@@ -88,7 +84,6 @@ def down(path: Path = typer.Argument("dockfleet.yaml")):
         typer.echo(f"Error stopping services: {e}")
         raise typer.Exit(code=1)
 
-
 @app.command()
 def ps():
     """Show currently running DockFleet containers."""
@@ -101,7 +96,6 @@ def ps():
     except Exception as e:
         typer.echo(f"Error listing containers: {e}")
         raise typer.Exit(code=1)
-
 
 @app.command()
 def doctor():
@@ -127,7 +121,6 @@ def doctor():
     except Exception:
         typer.echo("✗ Docker not found or not running")
         raise typer.Exit(code=1)
-
 
 @app.command("health-dev")
 def health_dev(
@@ -179,19 +172,19 @@ def health_dev(
                     continue
                 ok = scheduler._run_single_check(name, hc)
                 status_str = "HEALTHY" if ok else "UNHEALTHY"
-                typer.echo(f"[once] {name} -> {status_str}")
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                typer.echo(f"[{timestamp}] {name}: {status_str.lower()}")
                 update_service_health(
                     name,
                     ok,
                     reason=None if ok else "health check failed",
                 )
                 scheduler._handle_post_health(name)
-            typer.echo("Single health pass complete.")
+        typer.echo("Single health pass complete.")
         return
 
-
         # Normal long-running mode
-        scheduler.start()
+        typer.echo("Health monitoring started...")
 
         try:
             while True:
@@ -203,7 +196,6 @@ def health_dev(
     except Exception as e:
         typer.echo(f"Health scheduler failed: {e}")
         raise typer.Exit(code=1)
-
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
###  Health CLI UX Improvements

Enhanced the `dockfleet health-dev` command to make health monitoring easier to demonstrate and debug.

**Changes**

* Added timestamped health status output for each service (`[timestamp] service: healthy/unhealthy`)
* Improved CLI output for better visibility during health checks
* Added **Health Monitoring** section in README with CLI usage example
* Added instructions for installing DockFleet CLI locally using `pip install -e .`

These updates make it easier to demonstrate the health engine working during development and project demos.
