### PR TITLE
feat(logs): add docker logs streaming to dashboard via SSE

### DIFF
--- a/dockfleet/dashboard/routes.py
+++ b/dockfleet/dashboard/routes.py
@@ -2,12 +2,11 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from dockfleet.dashboard.services import get_services_from_db_or_mock
+from dockfleet.core.logs import stream_container_logs
 from pydantic import BaseModel
 from typing import List
 from datetime import datetime
 from typing import Optional
-import time
-import json
 
 router = APIRouter()
 
@@ -43,30 +42,6 @@ def list_services():
     """
     return get_services_from_db_or_mock()
 
-
-
-
-@router.get("/logs/{service}")
-def stream_service_logs(service: str):
-
-    def event_generator():
-        counter = 1
-        while True:
-            log_data = {
-                "service": service,
-                "message": f"Log entry {counter} from {service}",
-                "level": "INFO"
-            }
-
-            yield f"data: {json.dumps(log_data)}\n\n"
-            counter += 1
-            time.sleep(2)
-
-    return StreamingResponse(
-        event_generator(),
-        media_type="text/event-stream"
-    )
-
 @router.get("/status")
 def system_status():
 
@@ -92,5 +67,19 @@ def system_status():
         "restarting": restarting,
         "stopped": stopped
     }
-    
+
+@router.get("/logs/{service}")
+async def stream_logs(service: str):
+    """
+    Stream container logs to browser using Server Sent Events (SSE)
+    """
+
+    # For now service name = container name
+    container_name = f"dockfleet_{service}"
+
+    def event_stream():
+        for line in stream_container_logs(container_name):
+            yield f"data: {line}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream") 
     

--- a/dockfleet/dashboard/templates/index.html
+++ b/dockfleet/dashboard/templates/index.html
@@ -232,6 +232,46 @@
 
         </div>
 
+        <!-- LOG VIEWER -->
+<div class="mt-16">
+
+    <h2 class="text-2xl font-bold mb-4">Live Service Logs</h2>
+
+    <div class="flex gap-4 mb-4">
+
+        <!-- Service Selector -->
+        <select x-model="selectedService"
+            class="px-3 py-2 rounded bg-gray-200 dark:bg-gray-700">
+
+            <option value="">Select Service</option>
+
+            <template x-for="service in services">
+                <option :value="service.name" x-text="service.name"></option>
+            </template>
+
+        </select>
+
+        <!-- Start Logs Button -->
+        <button
+            @click="startLogs()"
+            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-500">
+
+            Start Logs
+
+        </button>
+
+    </div>
+
+    <!-- Logs Container -->
+    <div
+        x-ref="logBox"
+        class="bg-black text-green-400 font-mono text-xs p-4 rounded-xl
+               h-72 overflow-y-auto">
+
+    </div>
+
+</div>
+
     </div>
 
 

--- a/dockfleet/dashboard/templates/index.html
+++ b/dockfleet/dashboard/templates/index.html
@@ -284,6 +284,8 @@
 
                 services: [],
                 summary: {},
+                selectedService: "",
+                logSource: null,
 
                 async init() {
 
@@ -375,6 +377,39 @@
                     console.log("Stop clicked:", name)
 
                 },
+
+                startLogs() {
+
+    if (!this.selectedService) {
+        alert("Select a service first")
+        return
+    }
+
+    // close previous stream
+    if (this.logSource) {
+        this.logSource.close()
+    }
+
+    // clear logs
+    this.$refs.logBox.innerHTML = ""
+
+    // connect to SSE endpoint
+    this.logSource = new EventSource(`/logs/${this.selectedService}`)
+
+    this.logSource.onmessage = (event) => {
+
+        const line = document.createElement("div")
+
+        line.textContent = event.data
+
+        this.$refs.logBox.appendChild(line)
+
+        this.$refs.logBox.scrollTop =
+            this.$refs.logBox.scrollHeight
+
+    }
+
+},
 
                 toggleDarkMode() {
 


### PR DESCRIPTION
### Description

- implement docker logs wrapper using subprocess
-  add FastAPI /logs/{service} streaming endpoint
-  stream logs using Server Sent Events
-  add dashboard log viewer with service selector

<img width="1566" height="449" alt="image" src="https://github.com/user-attachments/assets/6f15c2f7-ad1f-4149-a554-9c019477a1e2" />
