### PR TITLE
Health engine: logging plumbing, dashboard queries, and self‑healing toggle support

### DIFF
--- a/dockfleet/core/orchestrator.py
+++ b/dockfleet/core/orchestrator.py
@@ -5,16 +5,35 @@ from dockfleet.health.status import (
     mark_restart_successful,
     record_restart_event
 )
-
+import subprocess
 from dockfleet.health.models import Service, engine
 from dockfleet.health.seed import bootstrap_from_config
 import logging
 from sqlmodel import Session, select
 from datetime import datetime
 from typing import Optional
+from dockfleet.cli.config import RestartPolicy
 
 logger = logging.getLogger(__name__)
 
+_orchestrator_instance = None
+
+def get_orchestrator(config=None):
+    """Get/create global Orchestrator instance."""
+    global _orchestrator_instance
+    if _orchestrator_instance is None:
+        _orchestrator_instance = Orchestrator(config or {})
+    return _orchestrator_instance
+
+def restart_service(name: str, config=None) -> bool:
+    """Module wrapper for HealthScheduler."""
+    orch = get_orchestrator(config)
+    return orch.restart_service(name, config)
+
+def mark_restart_failed(name: str, reason: str) -> None:
+    """Module wrapper for HealthScheduler."""
+    orch = get_orchestrator()
+    orch._mark_restart_failed(name, reason)
 
 class Orchestrator:
 
@@ -69,15 +88,27 @@ class Orchestrator:
             print(f"Failed to stop {name}")
             print(e)
 
-    def restart_service(self, service_name: str, config=None) -> bool:
-
+    def restart_service(self, service_name: str, config=None, backoff_attempt: int = 0) -> bool:
         config = config or self.config
         
         if service_name not in config.services:
             logger.warning(f"Service {service_name} not found")
             return False
         
-        import subprocess
+        svc = config.services[service_name]
+        
+        if svc.restart == RestartPolicy.never: 
+            logger.info(f"{service_name}: restart='never', skipping")
+            return False
+        
+        if backoff_attempt > 0:
+            import time
+            delay = min(2 ** backoff_attempt, 32)
+            logger.info(f"{service_name}: backoff {delay}s (attempt {backoff_attempt})")
+            time.sleep(delay)
+        
+        logger.info(f"Restarting {service_name}")
+        
         container_name = self.container_name(service_name)
         try:
             result = subprocess.run(
@@ -85,29 +116,25 @@ class Orchestrator:
                 capture_output=True, text=True, timeout=5
             )
             if not result.stdout.strip():
-                logger.info(f"{service_name} not running, skipping restart")
+                logger.info(f"{service_name} not running, skipping")
                 return False
         except:
             logger.warning(f"Cannot check {service_name}, skipping")
             return False
         
-        svc = config.services[service_name]
-        print(f"Restarting container: {service_name}")
-        
         try:
-            # Stop container
             self.stop_service(service_name)
-            
             self._increment_restart_count(service_name)
-            
-            # Start fresh
             self.start_service(service_name, svc)
-            logger.info(f"{service_name} restarted (restart_count incremented)")
+            
+            logger.info(f"{service_name} restarted (count updated)")
             return True
             
         except Exception as e:
-            logger.error(f"Container restart failed: {e}")
+            logger.error(f"{service_name} restart FAILED: {e}")
             return False
+
+
 
     def _increment_restart_count(self, service_name: str) -> None:
         try:

--- a/dockfleet/health/logs.py
+++ b/dockfleet/health/logs.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from sqlmodel import Session
-
+from sqlmodel import Session, select
 from .models import LogEvent, Service, engine
 
 

--- a/dockfleet/health/logs.py
+++ b/dockfleet/health/logs.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from sqlmodel import Session
+
+from .models import LogEvent, Service, engine
+
+
+def store_log_line(service_name: str, message: str, level: str | None = None, source: str | None = None) -> None:
+    """
+    Lightweight helper to store a single log metadata row.
+
+    This will be called from CLI/SSE log streaming in Week 3.
+    """
+    with Session(engine) as session:
+        svc = session.exec(
+            select(Service).where(Service.name == service_name)
+        ).one_or_none()
+
+        if svc is None:
+            # Best-effort: we can still store the name with a fake id.
+            # For now, just skip to keep it simple.
+            print(f"[logs] Service '{service_name}' not found in DB")
+            return
+
+        event = LogEvent(
+            service_id=svc.id,
+            service_name=svc.name,
+            created_at=datetime.utcnow(),
+            level=level,
+            message=message,
+            source=source,
+        )
+
+        session.add(event)
+        session.commit()

--- a/dockfleet/health/queries.py
+++ b/dockfleet/health/queries.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from typing import Any, Dict, List
+from sqlmodel import Session, select
+from .models import Service, engine
+
+
+def get_all_services() -> list[Service]:
+    """
+    Low-level helper: return all Service rows from SQLite.
+    Dashboard/API layer can either use these ORM objects directly
+    or call get_services_for_dashboard() for JSON-ready dicts.
+    """
+    with Session(engine) as session:
+        services = session.exec(select(Service)).all()
+    return services
+
+
+def get_services_for_dashboard() -> list[dict[str, Any]]:
+    """
+    High-level helper: return services as plain dicts suitable
+    for the /services dashboard API response.
+    These dicts can be easily enriched with orchestrator stats
+    (CPU, memory, uptime) before sending to the frontend.
+    """
+    services = get_all_services()
+
+    result: list[dict[str, Any]] = []
+    for svc in services:
+        result.append(
+            {
+                "name": svc.name,
+                "status": svc.status,
+                "restart_count": svc.restart_count,
+                "last_health_check": svc.last_health_check,
+                # extra health-engine fields that may be useful to the UI
+                "consecutive_failures": svc.consecutive_failures,
+                "last_failure_reason": svc.last_failure_reason,
+            }
+        )
+    return result

--- a/dockfleet/health/scheduler.py
+++ b/dockfleet/health/scheduler.py
@@ -126,6 +126,30 @@ class HealthScheduler:
         This keeps the decision logic on the health side and the actual
         container restart on the orchestrator side.
         """
+        #self-healing toggle from config
+        svc_cfg = self.config.services.get(name)
+        if svc_cfg is None:
+            return
+
+        # Service-level override > top-level default.
+        # Assumes DockFleetConfig has `self_healing: bool` and
+        # ServiceConfig has `self_healing: bool | None`.
+        service_self_healing = getattr(svc_cfg, "self_healing", None)
+        if service_self_healing is None:
+            self_healing = getattr(self.config, "self_healing", True)
+        else:
+            self_healing = service_self_healing
+
+        if not self_healing:
+            # Auto-restart disabled for this service (or globally)
+            self._logger.debug(
+                "HealthScheduler: self-healing disabled for %s, "
+                "skipping auto-restart",
+                name,
+            )
+            return
+
+        #Load latest DB state
         with Session(engine) as session:
             svc = session.exec(
                 select(Service).where(Service.name == name)
@@ -138,6 +162,7 @@ class HealthScheduler:
             )
             return
 
+        #Check failure threshold + restart policy
         if not needs_restart(svc):
             return
 
@@ -149,8 +174,8 @@ class HealthScheduler:
             svc.consecutive_failures,
         )
 
+        #Delegate to orchestrator
         try:
-            # Orchestrator does the real Docker restart.
             restart_service(svc.name, self.config)
 
             # On success: reset streak, mark running, and record event.

--- a/docs/logging_design.md
+++ b/docs/logging_design.md
@@ -35,3 +35,15 @@ Frontend / dashboard can then:
 - Query recent `LogEvent` rows per service for a "Recent events" sidebar.
 - Build crash analytics (e.g. “most unstable services”, timeline of errors) from
   this metadata, while still using live SSE for full log streaming.
+
+## Writers: how logs will reach LogEvent
+
+- CLI `dockfleet logs` and the SSE backend that tails `docker logs -f` can
+  call `store_log_line(service_name, message, level, source="docker-logs")`
+  for sampled / important lines (e.g. only `ERROR` or first line of a burst).
+
+- Health scheduler / orchestrator can also write structured events:
+  `store_log_line(name, "auto-restart failed", level="ERROR", source="scheduler")`.
+
+Later, crash analytics / dashboard can query `LogEvent` by `service_id`,
+`level`, and `created_at` to show timelines and “most error-prone services”.


### PR DESCRIPTION
- Log metadata groundwork
  - Introduced a LogEvent SQLModel to store lightweight log metadata (service id/name, timestamp, level, message, source).
  - Added a store_log_line‑style writer stub and documented in logging_design.md how future CLI/SSE log streaming and system components can feed LogEvent for crash analytics.

- DB query helpers for dashboard /services
  - Added get_all_services() and get_services_for_dashboard() in dockfleet/health/queries.py to read service state from SQLite.
  - These helpers return either SQLModel objects or JSON‑friendly dicts (name, status, restart_count, last_health_check, failure streak) that the dashboard API can join with orchestrator stats (CPU/memory) before responding.

- Scheduler respects self‑healing toggle (joint with Sunidhi’s CLI work)
  - Updated HealthScheduler._handle_post_health to read self_healing from config (service‑level override with top‑level default) and skip auto‑restart when disabled.
  - Auto‑restart flow remains the same when enabled: after 3 consecutive failures and a restart‑able policy, the scheduler calls restart_service, then mark_restart_successful and record_restart_event, or mark_restart_failed on errors.