### PR TITLE
Add self-heal command for continuous self-healing loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,17 @@ Restart policies:
 - `on-failure` → restart only when a failure is detected
 - `never` → service will never restart automatically
 
+### Self-Healing Demo
+
+Run DockFleet in automatic recovery mode:
+
+```
+dockfleet self-heal examples/dockfleet.yaml
+```
+
+If a service fails health checks three times consecutively,
+DockFleet automatically restarts the container according to its restart policy.
+
 ---
 
 ### <u>Tech Stack</u>

--- a/dockfleet/cli/main.py
+++ b/dockfleet/cli/main.py
@@ -205,6 +205,38 @@ def health_dev(
     except Exception as e:
         typer.echo(f"Health scheduler failed: {e}")
         raise typer.Exit(code=1)
+@app.command("self-heal")
+def self_heal(
+    path: Path = typer.Argument("dockfleet.yaml")
+):
+    """
+    Run DockFleet in continuous self-healing mode.
+    Health checks run continuously and unhealthy services are restarted automatically.
+    """
+    try:
+        typer.echo("Starting DockFleet self-healing loop...\n")
 
+        config = load_config(path)
+
+        typer.echo(f"Bootstrapping health DB from {path} ...")
+        bootstrap_from_path(str(path))
+
+        scheduler = HealthScheduler(config)
+
+        typer.echo("Self-healing active. Press Ctrl+C to stop.\n")
+
+        scheduler.start()
+
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            typer.echo("\nStopping self-healing loop...")
+            scheduler.stop()
+
+    except Exception as e:
+        typer.echo(f"Self-heal command failed: {e}")
+        raise typer.Exit(code=1)
+    
 if __name__ == "__main__":
     app()

--- a/examples/dockfleet.yaml
+++ b/examples/dockfleet.yaml
@@ -2,7 +2,7 @@ self_healing: true
 
 services:
   api:
-    image: my-api:latest
+    image: nginx:latest
     ports:
       - "8000:8000"
     healthcheck:


### PR DESCRIPTION
Implements self-healing execution flow.

Changes:
- Added new CLI command `dockfleet self-heal` to run the continuous health monitoring loop.
- HealthScheduler runs automatically and restarts unhealthy services based on restart policy.
- Added a short "Self-Healing Demo" section in README showing how to run the self-heal loop.

This enables DockFleet to run end-to-end automatic recovery for unhealthy services.