### PR TITLE
Add CLI logs command for service containers

### DIFF
--- a/dockfleet/cli/main.py
+++ b/dockfleet/cli/main.py
@@ -8,7 +8,7 @@ from dockfleet.health.status import update_service_health
 import typer
 from pydantic import ValidationError
 from dockfleet.cli.config import load_config
-from dockfleet.core.orchestrator import Orchestrator
+from dockfleet.core.orchestrator import Orchestrator, get_logs
 from dockfleet.health.seed import bootstrap_from_path
 from dockfleet.health.scheduler import HealthScheduler
 from dockfleet.health.models import sqlite_file_name  
@@ -97,6 +97,25 @@ def ps():
         typer.echo(f"Error listing containers: {e}")
         raise typer.Exit(code=1)
 
+@app.command()
+def logs(
+    service: str = typer.Argument(..., help="Service name"),
+    lines: int = typer.Option(100, "--lines", help="Number of log lines to show"),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
+):
+    """
+    Show logs for a DockFleet service container.
+    """
+    try:
+        output = get_logs(service, lines=lines, follow=follow)
+
+        if output:
+            typer.echo(output)
+
+    except Exception as e:
+        typer.echo(f"Failed to fetch logs for {service}: {e}")
+        raise typer.Exit(code=1)
+    
 @app.command()
 def doctor():
     """Check system environment (Python version and Docker availability)."""


### PR DESCRIPTION
Changes:
- Added `dockfleet logs SERVICE` command to fetch Docker container logs.
- Supports `--lines` option to limit output.
- Supports optional `--follow` flag.

This allows developers to inspect service logs directly from the DockFleet CLI and helps test the logs wrapper used by the dashboard backend.