### PR TITLE
feat(orchestrator/docker): add resilient log streaming and service stats helper

### DIFF
--- a/dockfleet/core/logs.py
+++ b/dockfleet/core/logs.py
@@ -1,29 +1,48 @@
+# dockfleet/api/logs.py
+from fastapi.responses import StreamingResponse
+from fastapi import HTTPException
 import subprocess
-from subprocess import PIPE, STDOUT
+import logging
+from dockfleet.core.orchestrator import get_container_name
 
+logger = logging.getLogger(__name__)
 
-def stream_container_logs(container_name: str):
-    """
-    Stream logs from a Docker container using docker logs -f.
-    Yields log lines continuously as they appear.
-    """
-
-    process = subprocess.Popen(
-        ["docker", "logs", "-f", container_name],
-        stdout=PIPE,
-        stderr=STDOUT,
-        text=True,
-        bufsize=1
-    )
-
+async def stream_logs(service_name: str):
+    """Stream Docker logs → SSE with resilience."""
+    container = get_container_name(service_name)
+    
+    # Check container exists first
     try:
-        # Read logs line-by-line
-        for line in iter(process.stdout.readline, ""):
-            yield line.strip()
-
-    except Exception as e:
-        yield f"[ERROR] {str(e)}"
-
+        result = subprocess.run(
+            ["docker", "ps", "-a", "--filter", f"name={container}", "--format", "{{.Names}}"],
+            capture_output=True, text=True, timeout=5
+        )
+        if not result.stdout.strip():
+            yield f"data: {{ \"error\": \"Container {container} not found\" }}\n\n"
+            return
+    except Exception:
+        yield f"data: {{ \"error\": \"Failed to check container {container}\" }}\n\n"
+        return
+    
+    # Stream logs with tail=100, follow
+    cmd = ["docker", "logs", "--tail", "100", "-f", container]
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, 
+        text=True, bufsize=1, universal_newlines=True
+    )
+    
+    try:
+        for line in proc.stdout:
+            line = line.rstrip()
+            if line:
+                yield f"data: {line}\n\n"
+    except GeneratorExit:
+        logger.info(f"Client disconnected from {container} logs")
     finally:
-        # Ensure process is terminated
-        process.kill()
+        # Cleanup Popen on disconnect/timeout
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        logger.info(f"Logs stream for {container} cleaned up")

--- a/dockfleet/core/orchestrator.py
+++ b/dockfleet/core/orchestrator.py
@@ -6,6 +6,7 @@ from dockfleet.health.status import (
     record_restart_event
 )
 import subprocess
+import re
 from dockfleet.health.models import Service, engine
 from dockfleet.health.seed import bootstrap_from_config
 import logging
@@ -71,7 +72,6 @@ def get_logs(service_name: str, lines: int = 100, follow: bool = False) -> str:
     except Exception as e:
         logger.error(f"Failed to get logs for {container_name}: {e}")
         return f"Error: {e}"
-
 
 
 class Orchestrator:
@@ -267,49 +267,50 @@ class Orchestrator:
         self.docker.list_containers()
 
     def get_service_stats(self) -> list[ServiceStat]:
-        """Get Docker stats for all dockfleet_ containers."""
+        """Enhanced Docker stats with inspect data."""
         stats = []
         
         try:
-    
             result = subprocess.run([
-                "docker", "stats", "--no-stream", "--no-trunc", 
-                "--format", "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.Uptime}}"
+                "docker", "stats", "--no-stream", "--no-trunc",
+                "--format", "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}"
             ], capture_output=True, text=True, timeout=10)
             
             if result.returncode != 0:
-                return [ServiceStat(service_name="error", container_name="error", status="docker_failed")]
+                self.logger.warning("Docker stats failed")
+                return self._get_missing_stats()
             
-            lines = result.stdout.strip().split('\n')[1:]
+            lines = [line for line in result.stdout.strip().split('\n')[1:] if line.strip()]
             
             for line in lines:
-                if not line.strip():
-                    continue
                 parts = line.split('\t')
-                if len(parts) >= 5:
+                if len(parts) >= 4 and parts[0].startswith('dockfleet_'):
                     container = parts[0].strip()
-                    if container.startswith('dockfleet_'):
-                        service_name = container.replace('dockfleet_', '')
-                        stats.append(ServiceStat(
-                            service_name=service_name,
-                            container_name=container,
-                            cpu_percent=float(parts[1].replace('%', '')) if parts[1] != '0.00%' else 0.0,
-                            mem_current=parts[2],
-                            mem_percent=parts[3],
-                            uptime=parts[4],
-                            status="running"
-                        ))
+                    service_name = container.replace('dockfleet_', '')
+                    
+                    # Parse stats
+                    cpu_str, mem_usage, mem_perc = parts[1:4]
+                    cpu = float(re.sub(r'[^\d.]', '', cpu_str)) if cpu_str != '0.00%' else 0.0
+                    mem_current, mem_limit = mem_usage.split('/')
+                    uptime = self._get_container_uptime(container)
+                    
+                    stats.append(ServiceStat(
+                        service_name=service_name,
+                        container_name=container,
+                        cpu_percent=cpu,
+                        mem_current=f"{mem_current}/{mem_limit}",
+                        mem_percent=mem_perc.strip(),
+                        uptime=uptime,
+                        status="running"
+                    ))
         
-        except subprocess.TimeoutExpired:
-            return [ServiceStat(service_name="timeout", status="docker_timeout")]
         except Exception as e:
-            return [ServiceStat(service_name="error", status=f"exception: {str(e)}")]
+            self.logger.error(f"Stats collection failed: {e}")
+            return self._get_missing_stats()
         
-        # Add missing services as stopped
-        expected_containers = [f"dockfleet_{name}" for name in self.config.services.keys()]
-        found_containers = {stat.container_name for stat in stats}
-        for container in expected_containers:
-            if container not in found_containers:
+        expected = [f"dockfleet_{name}" for name in self.config.services]
+        for container in expected:
+            if container not in {s.container_name for s in stats}:
                 service_name = container.replace('dockfleet_', '')
                 stats.append(ServiceStat(
                     service_name=service_name,
@@ -318,3 +319,28 @@ class Orchestrator:
                 ))
         
         return sorted(stats, key=lambda x: x.service_name)
+
+    def _get_container_uptime(self, container_name: str) -> str:
+        """Get uptime from docker inspect."""
+        try:
+            result = subprocess.run([
+                "docker", "inspect", container_name,
+                "--format", "{{.State.StartedAt}}"
+            ], capture_output=True, text=True, timeout=5)
+            if result.returncode == 0:
+                started_at = result.stdout.strip()
+                return f"Up {started_at.split('T')[1].split('.')[0]}"
+        except:
+            pass
+        return "Unknown"
+
+    def _get_missing_stats(self) -> list[ServiceStat]:
+        """Return all services as unknown."""
+        return [
+            ServiceStat(
+                service_name=name,
+                container_name=f"dockfleet_{name}",
+                status="unknown"
+            )
+            for name in self.config.services.keys()
+        ]

--- a/dockfleet/core/orchestrator.py
+++ b/dockfleet/core/orchestrator.py
@@ -11,12 +11,27 @@ from dockfleet.health.seed import bootstrap_from_config
 import logging
 from sqlmodel import Session, select
 from datetime import datetime
+from pydantic import BaseModel
 from typing import Optional
 from dockfleet.cli.config import RestartPolicy
 
 logger = logging.getLogger(__name__)
 
+class ServiceStat(BaseModel):
+    service_name: str
+    container_name: str
+    cpu_percent: Optional[float] = None
+    mem_current: Optional[str] = None
+    mem_percent: Optional[str] = None
+    uptime: Optional[str] = None
+    status: str = "unknown"  # running, stopped, missing
+
 _orchestrator_instance = None
+
+def get_service_stats(config=None):
+    """Module wrapper for stats."""
+    orch = get_orchestrator(config)
+    return orch.get_service_stats()
 
 def get_orchestrator(config=None, self_healing: bool = True):
     """Get/create global Orchestrator instance."""
@@ -56,6 +71,8 @@ def get_logs(service_name: str, lines: int = 100, follow: bool = False) -> str:
     except Exception as e:
         logger.error(f"Failed to get logs for {container_name}: {e}")
         return f"Error: {e}"
+
+
 
 class Orchestrator:
 
@@ -248,3 +265,56 @@ class Orchestrator:
         print("Running containers:\n")
 
         self.docker.list_containers()
+
+    def get_service_stats(self) -> list[ServiceStat]:
+        """Get Docker stats for all dockfleet_ containers."""
+        stats = []
+        
+        try:
+    
+            result = subprocess.run([
+                "docker", "stats", "--no-stream", "--no-trunc", 
+                "--format", "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.Uptime}}"
+            ], capture_output=True, text=True, timeout=10)
+            
+            if result.returncode != 0:
+                return [ServiceStat(service_name="error", container_name="error", status="docker_failed")]
+            
+            lines = result.stdout.strip().split('\n')[1:]
+            
+            for line in lines:
+                if not line.strip():
+                    continue
+                parts = line.split('\t')
+                if len(parts) >= 5:
+                    container = parts[0].strip()
+                    if container.startswith('dockfleet_'):
+                        service_name = container.replace('dockfleet_', '')
+                        stats.append(ServiceStat(
+                            service_name=service_name,
+                            container_name=container,
+                            cpu_percent=float(parts[1].replace('%', '')) if parts[1] != '0.00%' else 0.0,
+                            mem_current=parts[2],
+                            mem_percent=parts[3],
+                            uptime=parts[4],
+                            status="running"
+                        ))
+        
+        except subprocess.TimeoutExpired:
+            return [ServiceStat(service_name="timeout", status="docker_timeout")]
+        except Exception as e:
+            return [ServiceStat(service_name="error", status=f"exception: {str(e)}")]
+        
+        # Add missing services as stopped
+        expected_containers = [f"dockfleet_{name}" for name in self.config.services.keys()]
+        found_containers = {stat.container_name for stat in stats}
+        for container in expected_containers:
+            if container not in found_containers:
+                service_name = container.replace('dockfleet_', '')
+                stats.append(ServiceStat(
+                    service_name=service_name,
+                    container_name=container,
+                    status="stopped"
+                ))
+        
+        return sorted(stats, key=lambda x: x.service_name)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,66 @@
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+from dockfleet.core.logs import stream_logs
+from dockfleet.core.orchestrator import get_container_name
+
+def test_get_container_name():
+    """Helper works."""
+    assert get_container_name("api") == "dockfleet_api"
+
+@patch('dockfleet.core.logs.subprocess.run')
+@pytest.mark.asyncio
+async def test_container_missing(mock_run):
+    """Container not found → SSE error."""
+    mock_run.return_value = MagicMock(returncode=0, stdout="")
+    
+    events = []
+    async for event in stream_logs("missing"):
+        events.append(event)
+        break
+    
+    assert len(events) == 1
+    assert '"Container dockfleet_missing not found"' in events[0]
+    mock_run.assert_called_once()
+
+@patch('dockfleet.core.logs.subprocess.run')
+@pytest.mark.asyncio
+async def test_docker_check_fails(mock_run):
+    """Docker ps fails → error SSE."""
+    mock_run.side_effect = Exception("Docker error")
+    
+    events = []
+    async for event in stream_logs("api"):
+        events.append(event)
+        break
+    
+    assert len(events) == 1
+    assert '"Failed to check container dockfleet_api"' in events[0]
+
+@patch('dockfleet.core.logs.subprocess.Popen')
+@patch('dockfleet.core.logs.subprocess.run')
+@pytest.mark.asyncio
+async def test_logs_streaming(mock_run, mock_popen):
+    """Container exists → streams SSE."""
+    # Container check passes
+    mock_run.side_effect = [
+        MagicMock(returncode=0, stdout="dockfleet_test\n"),  # docker ps
+    ]
+    
+    # Mock log lines
+    mock_popen.return_value.stdout = iter([
+        "log line 1\n",
+        "log line 2\n",
+    ])
+
+    mock_popen.return_value.terminate = MagicMock()
+    mock_popen.return_value.wait = MagicMock(return_value=0)
+
+    events = []
+    async for event in stream_logs("test"):
+        events.append(event)
+        if len(events) >= 2:
+            break
+    
+    assert len(events) >= 1
+    assert all("data: " in event for event in events)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,3 +6,66 @@ from dockfleet.core.orchestrator import Orchestrator, get_service_stats
 def test_get_service_stats(mock_run):
     """Test stats parsing."""
     mock_run.return_value
+
+import pytest
+from unittest.mock import patch, MagicMock, Mock
+from dockfleet.core.orchestrator import Orchestrator, get_container_name
+from dockfleet.core.orchestrator import ServiceStat
+
+@pytest.fixture
+def mock_config():
+    """Mock config."""
+    config = Mock()
+    config.services = {
+        "api": Mock(image="nginx", ports=[80]),
+        "web": Mock(image="nginx", ports=[8080])
+    }
+    return config
+
+@pytest.fixture
+def orchestrator(mock_config):
+    """Mocked orchestrator."""
+    orch = Mock(spec=Orchestrator)
+    orch.config = mock_config
+    orch.container_name = Mock(side_effect=lambda name: f"dockfleet_{name}")
+    orch.docker = Mock()
+    orch.logger = Mock()
+    return orch
+
+def test_get_container_name():
+    """Basic container naming."""
+    assert get_container_name("api") == "dockfleet_api"
+    assert get_container_name("web") == "dockfleet_web"
+
+@patch('subprocess.run')
+def test_docker_ps_check(mock_run):
+    """Test container existence check."""
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="dockfleet_api\n"
+    )
+    
+    # Simulate restart_service container check
+    result = mock_run.return_value.stdout.strip()
+    assert "dockfleet_api" in result
+
+@patch('dockfleet.core.orchestrator.Orchestrator')
+def test_get_service_stats_wrapper(mock_orch_class):
+    """Module wrapper works."""
+    mock_orch = mock_orch_class.return_value
+    mock_orch.get_service_stats.return_value = [
+        ServiceStat(service_name="api", container_name="dockfleet_api", status="running")
+    ]
+    
+    from dockfleet.core.orchestrator import get_service_stats
+    stats = get_service_stats()
+    
+    assert len(stats) == 1
+    mock_orch.get_service_stats.assert_called_once()
+
+@pytest.mark.parametrize("service_name", ["api", "web", "db"])
+def test_container_naming_consistent(service_name):
+    """All services use dockfleet_ prefix."""
+    name = get_container_name(service_name)
+    assert name == f"dockfleet_{service_name}"
+    assert name.startswith("dockfleet_")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,8 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from dockfleet.core.orchestrator import Orchestrator, get_service_stats
+
+@patch('subprocess.run')
+def test_get_service_stats(mock_run):
+    """Test stats parsing."""
+    mock_run.return_value


### PR DESCRIPTION
- Make Docker log streaming wrapper resilient.
- Handle case where container does not exist by emitting a friendly SSE error event and closing the stream.
- Ensure proper cleanup of the Popen process using try/finally when the FastAPI client disconnects.
- Optionally limit historical logs using `--tail N` before `-f` to avoid extremely long log streams.

- Add orchestrator helper `get_service_stats()` that runs `docker stats --no-stream`.
- Collect per-service CPU and memory usage and map results by container name.
- Use `docker inspect` where needed to derive additional metadata such as uptime.

- Return a trimmed `ServiceStat` structure that can be consumed by the `/services` endpoint.
- Ensure the helper remains resilient when containers are missing or stopped.

- Update endpoints to return JSON including latest service status and `restart_count`
  so the UI can refresh service cards accurately.