### PR TITLE
feat(health+dashboard): sync DB with actions and expose service summaries

### DIFF
--- a/dockfleet/health/queries.py
+++ b/dockfleet/health/queries.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
-from typing import Any, Dict, List
+from typing import Any
 from sqlmodel import Session, select
 from .models import Service, engine
-
 
 def get_all_services() -> list[Service]:
     """
@@ -13,7 +12,6 @@ def get_all_services() -> list[Service]:
     with Session(engine) as session:
         services = session.exec(select(Service)).all()
     return services
-
 
 def get_services_for_dashboard() -> list[dict[str, Any]]:
     """
@@ -32,9 +30,44 @@ def get_services_for_dashboard() -> list[dict[str, Any]]:
                 "status": svc.status,
                 "restart_count": svc.restart_count,
                 "last_health_check": svc.last_health_check,
-                # extra health-engine fields that may be useful to the UI
                 "consecutive_failures": svc.consecutive_failures,
                 "last_failure_reason": svc.last_failure_reason,
             }
         )
     return result
+
+def get_services_for_dashboard_with_stats(
+    stats_by_name: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Enrich DB-based service state with Docker runtime stats
+    (CPU, memory, uptime, etc.), for the /services API.
+
+    stats_by_name example:
+        {
+          "api": {"cpu": 0.12, "memory": 128_000_000, "uptime": 42},
+          "redis": {"cpu": 0.01, "memory": 32_000_000, "uptime": 120},
+        }
+
+    Convention:
+    - cpu: fractional (0.12 = 12% CPU)
+    - memory: bytes
+    - uptime: seconds
+    """
+    base = get_services_for_dashboard()
+    enriched: list[dict[str, Any]] = []
+
+    for svc in base:
+        name = svc["name"]
+        stats = stats_by_name.get(name, {})
+
+        enriched.append(
+            {
+                **svc,
+                "cpu": stats.get("cpu"),
+                "memory": stats.get("memory"),
+                "uptime": stats.get("uptime"),
+            }
+        )
+
+    return enriched

--- a/dockfleet/health/queries.py
+++ b/dockfleet/health/queries.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from collections import Counter
 from typing import Any
 from sqlmodel import Session, select
 from .models import Service, engine
@@ -32,6 +33,9 @@ def get_services_for_dashboard() -> list[dict[str, Any]]:
                 "last_health_check": svc.last_health_check,
                 "consecutive_failures": svc.consecutive_failures,
                 "last_failure_reason": svc.last_failure_reason,
+                "image": svc.image,
+                "ports": svc.ports_raw,
+                "restart_policy": svc.restart_policy,
             }
         )
     return result
@@ -71,3 +75,17 @@ def get_services_for_dashboard_with_stats(
         )
 
     return enriched
+
+def get_status_counts() -> dict[str, int]:
+    """
+    Return a simple count of services per status, e.g.:
+    {"running": 2, "unhealthy": 1, "stopped": 1}
+    Useful for dashboard summary bar.
+    """
+    services = get_all_services()
+    counter: Counter[str] = Counter()
+
+    for svc in services:
+        counter[svc.status or "unknown"] += 1
+
+    return dict(counter)

--- a/dockfleet/health/status.py
+++ b/dockfleet/health/status.py
@@ -16,22 +16,22 @@ def _update_status(
 ) -> None:
     """Low-level helper to flip status for a service by name."""
     with Session(engine) as session:
-        existing = session.exec(
+        svc = session.exec(
             select(Service).where(Service.name == name)
         ).one_or_none()
 
-        if existing is None:
+        if svc is None:
             print(
                 f"[status] Service '{name}' not found in DB, skipping status update"
             )
             return
 
-        existing.status = new_status
+        svc.status = new_status
 
         if set_last_health:
-            existing.last_health_check = datetime.utcnow()
+            svc.last_health_check = datetime.utcnow()
 
-        session.add(existing)
+        session.add(svc)
         session.commit()
 
 def update_service_health(
@@ -41,18 +41,16 @@ def update_service_health(
 ) -> None:
     """
     Update Service row after a health check.
-
     - If healthy:
         status = "running"
         last_health_check updated
-        restart_count unchanged
         consecutive_failures reset to 0
+        restart_count unchanged
     - If unhealthy:
         status = "unhealthy"
         last_health_check updated
-        restart_count++
         consecutive_failures++
-        last_failure_reason stored (if provided)
+        restart_count unchanged (restart attempts are tracked separately)
     """
     with Session(engine) as session:
         svc = session.exec(
@@ -67,14 +65,10 @@ def update_service_health(
         svc.last_health_check = now
 
         if is_healthy:
-            # health OK -> treat as running service
             svc.status = "running"
-            # if we were failing before, reset the streak
             svc.consecutive_failures = 0
-            # restart_count unchanged here
         else:
             svc.status = "unhealthy"
-            svc.restart_count += 1
             svc.consecutive_failures += 1
             if reason:
                 svc.last_failure_reason = reason
@@ -103,7 +97,6 @@ def record_restart_event(service: Service, reason: str) -> None:
     Store a simple restart event for later crash analytics.
     Example reason: "3_failed_health_checks".
     """
-    # No DB lookup needed; we already have the Service instance.
     event = RestartEvent(
         service_id=service.id,
         restarted_at=datetime.utcnow(),
@@ -120,6 +113,8 @@ def mark_restart_successful(service_name: str) -> None:
     """
     Called by orchestrator after a successful auto-restart.
     Resets consecutive_failures and marks status as running.
+    Does NOT touch restart_count; that is incremented separately
+    for each restart attempt (auto or manual).
     """
     with Session(engine) as session:
         svc = session.exec(
@@ -132,6 +127,62 @@ def mark_restart_successful(service_name: str) -> None:
 
         svc.consecutive_failures = 0
         svc.status = "running"
+
+        session.add(svc)
+        session.commit()
+
+def record_manual_restart_event(service_name: str) -> None:
+    """
+    Called when a manual restart is triggered from the dashboard
+    and the orchestrator has successfully restarted the container.
+
+    - Increments restart_count (restart attempts).
+    - Marks status as 'running'.
+    - Inserts a RestartEvent with reason='manual_dashboard_restart'.
+    """
+    with Session(engine) as session:
+        svc = session.exec(
+            select(Service).where(Service.name == service_name)
+        ).one_or_none()
+
+        if svc is None:
+            print(f"[manual-restart] Service '{service_name}' not found in DB")
+            return
+
+        previous_status = svc.status
+        svc.restart_count = (svc.restart_count or 0) + 1
+        svc.status = "running"
+
+        event = RestartEvent(
+            service_id=svc.id,
+            restarted_at=datetime.utcnow(),
+            reason="manual_dashboard_restart",
+            previous_status=previous_status,
+            new_status="running",
+        )
+
+        session.add(svc)
+        session.add(event)
+        session.commit()
+
+def record_manual_stop(service_name: str) -> None:
+    """
+    Called when a manual stop is triggered from the dashboard
+    and the orchestrator has successfully stopped the container.
+
+    - Marks status as 'stopped'.
+    - Does NOT touch restart_count or consecutive_failures.
+    """
+    with Session(engine) as session:
+        svc = session.exec(
+            select(Service).where(Service.name == service_name)
+        ).one_or_none()
+
+        if svc is None:
+            print(f"[manual-stop] Service '{service_name}' not found in DB")
+            return
+
+        svc.status = "stopped"
 
         session.add(svc)
         session.commit()


### PR DESCRIPTION
- Add DB helpers to update service status and restart_count when dashboard Restart/Stop actions succeed.
- Expose JSON‑ready helpers for the /services endpoint, including basic health fields and Docker stats enrichment.
- Add a status summary helper that returns counts per status (running / unhealthy / stopped) for the dashboard summary bar.