### PR TITLE
feat(health): persist advanced service config for dashboard & analytics

### DIFF
--- a/dockfleet/health/models.py
+++ b/dockfleet/health/models.py
@@ -1,22 +1,37 @@
-from sqlmodel import Field, Session, SQLModel, create_engine
 from datetime import datetime
+from sqlmodel import Field, SQLModel, create_engine
 
 """
 Service table model
-fields: id, name, image, restart_policy, ports_raw, healthcheck_raw, status, restart_count, last_health_check, last_failure_reason, consecutive_failures
+fields:
+- id, name, image, restart_policy
+- ports_raw, healthcheck_raw
+- status, restart_count, last_health_check, last_failure_reason, consecutive_failures
+- resources_memory, resources_cpu, env_raw, depends_on_raw
 """
 class Service(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(nullable=False, unique=True)
     image: str = Field(nullable=False)
     restart_policy: str = Field(nullable=False)
+    # Serialized config fields
     ports_raw: str | None = Field(default=None)
     healthcheck_raw: str | None = Field(default=None)
+    # Runtime state fields
     status: str = Field(default="unknown", nullable=False)
     restart_count: int = Field(default=0, nullable=False)
     last_health_check: datetime | None = Field(default=None)
     last_failure_reason: str | None = Field(default=None)
     consecutive_failures: int = Field(default=0, nullable=False)
+    # Extra config for future dashboard / analytics
+    # Example: resources.memory: "512m", resources.cpu: 0.5
+    resources_memory: str | None = Field(default=None)
+    resources_cpu: float | None = Field(default=None)
+    # environment and depends_on stored in serialized form
+    # env_raw: JSON string (e.g. '["DB_URL=postgres://...", "REDIS_URL=..."]')
+    # depends_on_raw: comma-separated service names (e.g. "redis,db")
+    env_raw: str | None = Field(default=None)
+    depends_on_raw: str | None = Field(default=None)
 
 # RestartEvent table model
 # fields: id, service_id, restarted_at, reason, previous_status, new_status

--- a/dockfleet/health/queries.py
+++ b/dockfleet/health/queries.py
@@ -36,6 +36,10 @@ def get_services_for_dashboard() -> list[dict[str, Any]]:
                 "image": svc.image,
                 "ports": svc.ports_raw,
                 "restart_policy": svc.restart_policy,
+                "resources_memory": svc.resources_memory,
+                "resources_cpu": svc.resources_cpu,
+                "env": svc.env_raw,
+                "depends_on": svc.depends_on_raw,
             }
         )
     return result

--- a/dockfleet/health/services.py
+++ b/dockfleet/health/services.py
@@ -34,14 +34,36 @@ def services_from_config(config: DockFleetConfig) -> list[Service]:
             }
             healthcheck_raw = json.dumps(hc_dict)
 
-        # 4) Runtime defaults (not from config)
+        # 4) Resources → resources_memory / resources_cpu (optional)
+        if svc_cfg.resources is None:
+            resources_memory = None
+            resources_cpu = None
+        else:
+            resources_memory = svc_cfg.resources.memory
+            resources_cpu = svc_cfg.resources.cpu
+
+        # 5) Environment → env_raw (JSON string or None)
+        # ServiceConfig.environment: Optional[List[str]]
+        if svc_cfg.environment is None:
+            env_raw = None
+        else:
+            # store as JSON array of strings for future parsing
+            env_raw = json.dumps(svc_cfg.environment)
+
+        # 6) Depends_on → depends_on_raw (comma-separated or None)
+        if svc_cfg.depends_on is None:
+            depends_on_raw = None
+        else:
+            depends_on_raw = ",".join(svc_cfg.depends_on)
+
+        # 7) Runtime defaults (not from config)
         status = "stopped"
         restart_count = 0
         last_health_check = None
         last_failure_reason = None
         consecutive_failures = 0
 
-        # 5) Create Service instance not in DB
+        # 8) Create Service instance not in DB
         service = Service(
             name=name,
             image=image,
@@ -53,12 +75,15 @@ def services_from_config(config: DockFleetConfig) -> list[Service]:
             last_health_check=last_health_check,
             last_failure_reason=last_failure_reason,
             consecutive_failures=consecutive_failures,
+            resources_memory=resources_memory,
+            resources_cpu=resources_cpu,
+            env_raw=env_raw,
+            depends_on_raw=depends_on_raw,
         )
 
         services.append(service)
 
     return services
-
 
 def seed_services(config: DockFleetConfig, session: Session) -> None:
     services = services_from_config(config)

--- a/docs/database/service table.md
+++ b/docs/database/service table.md
@@ -34,17 +34,19 @@ Table: services
   - type: TEXT  
   - constraints: NOT NULL  
   - desc: Current service status (e.g., "running", "unhealthy", "restarting", "stopped").  
-  - note: Seed time: status is set to "stopped". Unknown / unhealthy states will only be used once the health engine is implemented in Week 2.
+  - note: Seed time: status is set to "stopped". Unknown / unhealthy states are used once the health engine runs.
 
 - restart_count  
   - type: INTEGER  
   - constraints: NOT NULL, DEFAULT 0  
-  - desc: Total number of times this service has been restarted by health engine.
+  - desc: Total number of times this service has been restarted  
+    (manual dashboard restart + auto self‑healing restarts).  
+    Health check failures alone do not change this.
 
 - last_health_check  
-  - type: DATETIME (or TEXT ISO string)  
+  - type: DATETIME (ISO string)  
   - constraints: NULL allowed  
-  - desc: Timestamp of last health check performed for this service.
+  - desc: Timestamp of the last health check performed for this service.
 
 - last_failure_reason  
   - type: TEXT  
@@ -55,4 +57,28 @@ Table: services
   - type: INTEGER  
   - constraints: NOT NULL, DEFAULT 0  
   - desc: Number of back‑to‑back failed health checks.  
-  - note: Used for "3 failed checks → restart" logic in later phases.
+  - note: Used for "3 failed checks → restart" logic in the health engine.
+
+- resources_memory  
+  - type: TEXT  
+  - constraints: NULL allowed  
+  - desc: Memory limit from config.resources.memory (e.g., "512m").  
+  - note: Stored for future dashboard display and crash analytics.
+
+- resources_cpu  
+  - type: REAL  
+  - constraints: NULL allowed  
+  - desc: CPU limit from config.resources.cpu (e.g., 0.5).  
+  - note: Stored for future dashboard display and crash analytics.
+
+- env_raw  
+  - type: TEXT  
+  - constraints: NULL allowed  
+  - desc: Serialized environment variables from config.environment  
+    (JSON array of strings, e.g., ["DB_URL=postgres://...", "REDIS_URL=..."]).  
+
+- depends_on_raw  
+  - type: TEXT  
+  - constraints: NULL allowed  
+  - desc: Serialized dependency list from config.depends_on  
+    (comma‑separated service names, e.g., "redis,db").


### PR DESCRIPTION
- Extend `Service` model with:
  - `resources_memory`, `resources_cpu`
  - `env_raw`, `depends_on_raw`
- Update seeding (`services_from_config`) to store:
  - `resources.*` from YAML
  - `environment` and `depends_on` in serialized form
- Expose new fields in `get_services_for_dashboard` so the dashboard
  can later show resource limits and env/depends_on info
- Refresh DB schema docs to match the new columns and semantics of:
  - `restart_count`
  - `status` and `consecutive_failures`