### PR TITLE
Add API response models and document dashboard controls

### DIFF
--- a/docs/dashboard/dashboard-architecture.md
+++ b/docs/dashboard/dashboard-architecture.md
@@ -18,3 +18,36 @@ Purpose:
 ## Run Locally
 
 uvicorn dockfleet.dashboard.api:app --reload --port 8080
+
+### Dashboard
+
+DockFleet provides a dashboard powered by FastAPI.
+
+The dashboard fetches service information from the `/services` endpoint.
+
+Fields returned by `/services`:
+
+name – service name  
+status – running / unhealthy / restarting / stopped  
+health_status – latest health check result  
+image – Docker image used by the service  
+ports – exposed container ports  
+restart_policy – restart policy of the service  
+restart_count – number of automatic restarts  
+last_health_check – timestamp of last health check
+
+Future versions will also expose CPU and memory usage.
+
+### Dashboard Controls
+
+The dashboard allows basic container control directly from the UI.
+
+Each service card includes:
+
+- **Restart** – triggers `POST /services/{name}/restart`
+- **Stop** – triggers `POST /services/{name}/stop`
+
+The dashboard fetches service data from the `/services` endpoint.
+
+Runtime fields such as **CPU usage**, **memory usage**, and **uptime** are retrieved from Docker using `docker stats`.  
+These metrics are **local-only** and are not sent to any external services.


### PR DESCRIPTION
Implements API contract documentation for the dashboard.

Changes:
- Added Pydantic models for ServiceView and ActionResponse.
- Attached response models to /services, restart, and stop endpoints.
- Updated README with Dashboard and Dashboard Controls sections explaining:
  - /services response fields
  - Restart and Stop dashboard actions
  - CPU/memory/uptime metrics sourced from Docker stats.