### PR TITLE
Extend YAML schema with resources, depends_on, environment validation

### DIFF
--- a/dockfleet/cli/config.py
+++ b/dockfleet/cli/config.py
@@ -1,28 +1,51 @@
 from enum import Enum
 from pathlib import Path
 from pydantic import BaseModel, Field, field_validator
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union
 import yaml
 import re
 
-# healthcheck model
+# Healthcheck Model
 class HealthCheckConfig(BaseModel):
     type: str
     endpoint: Optional[str] = None
     interval: Optional[int] = None
 
-# Restart policy Enum
+# Restart Policy Enum
+
 class RestartPolicy(str, Enum):
     always = "always"
     on_failure = "on-failure"
     never = "never"
 
-# Resource limits model
+# Resources Model
 class ResourcesConfig(BaseModel):
     memory: Optional[str] = None
     cpu: Optional[float] = None
 
-# service model
+    @field_validator("memory")
+    @classmethod
+    def validate_memory(cls, value):
+        if value is None:
+            return value
+
+        if not re.match(r"^\d+(m|g)$", value.lower()):
+            raise ValueError("invalid memory limit (expected like 512m or 1g)")
+
+        return value
+
+    @field_validator("cpu")
+    @classmethod
+    def validate_cpu(cls, value):
+        if value is None:
+            return value
+
+        if value <= 0:
+            raise ValueError("cpu must be positive")
+
+        return value
+
+# Service Model
 class ServiceConfig(BaseModel):
     image: str
     restart: RestartPolicy
@@ -30,9 +53,10 @@ class ServiceConfig(BaseModel):
     healthcheck: Optional[HealthCheckConfig] = None
     resources: Optional[ResourcesConfig] = None
     depends_on: Optional[List[str]] = None
-    environment: Optional[List[str]] = None
+    environment: Optional[Union[List[str], Dict[str, str]]] = None
     self_healing: Optional[bool] = None
 
+    #PORT VALIDATION 
     @field_validator("ports")
     @classmethod
     def validate_ports(cls, value):
@@ -49,6 +73,7 @@ class ServiceConfig(BaseModel):
 
         return value
 
+    #HEALTHCHECK VALIDATION 
     @field_validator("healthcheck")
     @classmethod
     def validate_healthcheck(cls, value):
@@ -63,15 +88,52 @@ class ServiceConfig(BaseModel):
 
         return value
 
+    #ENV VALIDATION
+    @field_validator("environment")
+    @classmethod
+    def validate_environment(cls, value):
+        if value is None:
+            return value
+
+        # list format → ["KEY=VALUE"]
+        if isinstance(value, list):
+            for item in value:
+                if "=" not in item:
+                    raise ValueError(
+                        f"Invalid environment entry '{item}', expected KEY=VALUE"
+                    )
+
+        # dict format → {"KEY": "VALUE"}
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                if not k or not isinstance(v, str):
+                    raise ValueError("Invalid environment dict format")
+
+        return value
+
 # Root Config Model
+
 class DockFleetConfig(BaseModel):
     self_healing: bool = True
     services: Dict[str, ServiceConfig]
+    
+    @field_validator("services")
+    @classmethod
+    def validate_depends_on(cls, services):
+        for name, svc in services.items():
+            if svc.depends_on:
+                for dep in svc.depends_on:
+                    if dep not in services:
+                        raise ValueError(
+                            f"{name}: depends_on references unknown service '{dep}'"
+                        )
+        return services
 
-# YAML loader
+# YAML Loader
 def load_config(path: Path) -> DockFleetConfig:
     with open(path, "r") as f:
         data = yaml.safe_load(f)
+
     if not data:
         raise ValueError("Config file is empty")
 

--- a/tests/test_config_advanced.py
+++ b/tests/test_config_advanced.py
@@ -1,0 +1,90 @@
+import pytest
+from dockfleet.cli.config import DockFleetConfig
+
+
+def test_valid_resources():
+    config = {
+        "services": {
+            "api": {
+                "image": "nginx",
+                "restart": "always",
+                "resources": {"memory": "512m", "cpu": 0.5},
+            }
+        }
+    }
+
+    DockFleetConfig(**config)
+
+
+def test_invalid_memory():
+    config = {
+        "services": {
+            "api": {
+                "image": "nginx",
+                "restart": "always",
+                "resources": {"memory": "500mb"},
+            }
+        }
+    }
+
+    with pytest.raises(ValueError):
+        DockFleetConfig(**config)
+
+
+def test_invalid_cpu():
+    config = {
+        "services": {
+            "api": {
+                "image": "nginx",
+                "restart": "always",
+                "resources": {"cpu": -1},
+            }
+        }
+    }
+
+    with pytest.raises(ValueError):
+        DockFleetConfig(**config)
+
+
+def test_invalid_depends_on():
+    config = {
+        "services": {
+            "api": {
+                "image": "nginx",
+                "restart": "always",
+                "depends_on": ["redis"],
+            }
+        }
+    }
+
+    with pytest.raises(ValueError):
+        DockFleetConfig(**config)
+
+
+def test_valid_environment_list():
+    config = {
+        "services": {
+            "api": {
+                "image": "nginx",
+                "restart": "always",
+                "environment": ["KEY=VALUE"],
+            }
+        }
+    }
+
+    DockFleetConfig(**config)
+
+
+def test_invalid_environment():
+    config = {
+        "services": {
+            "api": {
+                "image": "nginx",
+                "restart": "always",
+                "environment": ["INVALID"],
+            }
+        }
+    }
+
+    with pytest.raises(ValueError):
+        DockFleetConfig(**config)


### PR DESCRIPTION
Adds strict validation for advanced YAML config fields.

- Supports resources (memory, cpu)
- Validates depends_on references
- Supports environment (list and dict)
- Adds validation tests for config schema