### PR TITLE
Add CLI command for aggregated logs + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Each service specifies the Docker image, ports, restart policy, and optional hea
 DockFleet is similar to Docker Compose but focuses on lightweight local orchestration with built-in health monitoring and automatic recovery.  
 It is designed for small deployments and development environments where Kubernetes would be too complex.
 
-
-
 ---
 
 ## Advanced YAML Features
@@ -352,6 +350,20 @@ dockfleet logs api --follow
 ```
 
 The dashboard also supports live log streaming using Server-Sent Events (SSE).
+
+### Log Aggregation
+
+DockFleet provides a centralized log viewer across all services.
+
+- Logs from containers are stored in a SQLite database
+- View logs from all services in one place
+- Filter logs by service
+
+### CLI Example
+
+```bash
+dockfleet show-logs --service api --limit 50
+```
 
 ---
 

--- a/dockfleet/cli/main.py
+++ b/dockfleet/cli/main.py
@@ -146,7 +146,47 @@ def logs(
     except Exception:
         typer.echo(f"Service '{service}' not found or container not running.")
         raise typer.Exit(code=1)
-    
+@app.command("show-logs")
+def show_logs(
+    service: str = typer.Option(None, "--service", help="Filter by service name"),
+    limit: int = typer.Option(50, "--limit", help="Number of logs to show"),
+):
+    """
+    Show aggregated logs stored in DockFleet database.
+    """
+
+    try:
+        from sqlmodel import Session, select
+        from dockfleet.health.models import engine
+        from dockfleet.health.logs import LogEvent  # make sure this exists
+
+        with Session(engine) as session:
+            query = select(LogEvent).limit(limit)
+
+            if service:
+                query = query.where(LogEvent.service_name == service)
+
+            logs = session.exec(query).all()
+
+            if not logs:
+                typer.echo("No logs found.")
+                return
+
+            for log in logs:
+
+                ts = getattr(log, "timestamp", None) or getattr(log, "created_at", None)
+                if ts:
+
+                    ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+                else:
+                    ts = "no-time"
+
+                typer.echo(f"[{ts}] [{log.service_name}] {log.message}")
+
+    except Exception as e:
+        typer.echo(f"Failed to fetch logs: {e}")
+        raise typer.Exit(code=1)
+       
 @app.command()
 def doctor():
     """Check system environment (Python version and Docker availability)."""


### PR DESCRIPTION
- Added `dockfleet show-logs` command to view aggregated logs from SQLite
- Supports filtering by service and limiting results
- Updated README with log aggregation section

This enables centralized log viewing across services via CLI and dashboard.